### PR TITLE
avoid null errors

### DIFF
--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -19,11 +19,11 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
     });
 
     dataItems = legend;
-    preparedData = data;
+    preparedData = data || [];
   }
 
   if (!stacked) {
-    preparedData = data.map((item) => {
+    preparedData = (data || []).map((item) => {
       let val = item.value || item.data;
       if (isArray(val) && val.length > 0) {
         val = val[0];

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -12,7 +12,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
     referenceLineX, referenceLineY, fromDate, toDate }) => {
   const existingColors = {};
   let preparedLegend = [];
-  let preparedData = data;
+  let preparedData = data || [];
   const finalToDate = toDate || moment().utc();
   if (fromDate && finalToDate) {
     const timeFrame = chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;

--- a/src/components/Sections/SectionChart/SectionPieChart.js
+++ b/src/components/Sections/SectionChart/SectionPieChart.js
@@ -12,7 +12,7 @@ import { CHART_LAYOUT_TYPE } from '../../../constants/Constants';
 const SectionPieChart = ({ data, style, dimensions, legend, chartProperties = {}, legendStyle = {}, sortBy }) => {
   const dataMap = {};
   const existingColors = {};
-  data.forEach((item) => {
+  (data || []).forEach((item) => {
     item.value = item.value || item.data;
     if (isArray(item.value) && item.value.length > 0) {
       item.value = item.value[0];

--- a/src/components/Sections/SectionList.js
+++ b/src/components/Sections/SectionList.js
@@ -32,7 +32,7 @@ function styleByFieldName(fieldName, currentData) {
 }
 
 const SectionList = ({ columns, data, classes, style, title, titleStyle }) => {
-  let tableData = data;
+  let tableData = data || [];
 
   if (isString(data)) {
     try {


### PR DESCRIPTION
Sometimes users run to empty reports when widgets are empty. Make sure all charts accept empty values.