### PR TITLE
CircleCI use latest npm

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:8.11.0
+      - image: circleci/node:9
     resource_class: large
     working_directory: ~/sane-reports
     steps:
@@ -12,8 +12,8 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-              sudo npm install npm@4 -g
-              sudo npm install
+              sudo npm install npm@latest -g
+              npm install
       - save_cache:
           key: npm-sane-reports-{{ checksum "package.json" }}
           paths:


### PR DESCRIPTION
Can use node 9 only (others conflict with npm version and cause errors)