### PR TITLE
show default percentage label + minor table fix

### DIFF
--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -18,8 +18,8 @@ function getGridItemFromSection(section, overflowRows) {
   const rows = section.layout.rowPos + overflowRows;
   let height = section.layout.h;
   if (section.type === SECTION_TYPES.table && section.layout.w >= GRID_LAYOUT_COLUMNS) {
-    const numOfRows = (section.data.length + 1) * 0.66;
-    if (section.data.length > section.layout.h) {
+    const numOfRows = ((section.data.length || section.data.total) + 1) * 0.66;
+    if (numOfRows > section.layout.h) {
       height = numOfRows;
     }
   }

--- a/src/components/Sections/SectionChart/SectionPieChart.js
+++ b/src/components/Sections/SectionChart/SectionPieChart.js
@@ -9,7 +9,7 @@ import isArray from 'lodash/isArray';
 import { getGraphColorByName } from '../../../utils/colors';
 import { CHART_LAYOUT_TYPE, RADIANS } from '../../../constants/Constants';
 
-export const CustomizedPieLabel = ({ cx, cy, midAngle, outerRadius, percent, fill }) => {
+const CustomizedPieLabel = ({ cx, cy, midAngle, outerRadius, percent, fill }) => {
   const radius = outerRadius * 1.1;
   const x = cx + radius * Math.cos(-midAngle * RADIANS);
   const y = cy + radius * Math.sin(-midAngle * RADIANS);

--- a/src/components/Sections/SectionChart/SectionPieChart.js
+++ b/src/components/Sections/SectionChart/SectionPieChart.js
@@ -7,7 +7,38 @@ import merge from 'lodash/merge';
 import orderBy from 'lodash/orderBy';
 import isArray from 'lodash/isArray';
 import { getGraphColorByName } from '../../../utils/colors';
-import { CHART_LAYOUT_TYPE } from '../../../constants/Constants';
+import { CHART_LAYOUT_TYPE, RADIANS } from '../../../constants/Constants';
+
+export const CustomizedPieLabel = ({ cx, cy, midAngle, outerRadius, percent, fill }) => {
+  const radius = outerRadius * 1.1;
+  const x = cx + radius * Math.cos(-midAngle * RADIANS);
+  const y = cy + radius * Math.sin(-midAngle * RADIANS);
+  // ignore less than 2 percent.
+  if (percent < 0.02) {
+    return '';
+  }
+  return (
+    <text
+      x={x}
+      y={y}
+      fill={fill}
+      fontSize={12}
+      transform={`rotate(0,${x},${y})`}
+      textAnchor={x > cx ? 'start' : 'end'}
+      dominantBaseline="central"
+    >
+      {`${(percent * 100).toFixed(0)}%`}
+    </text>
+  );
+};
+CustomizedPieLabel.propTypes = {
+  cx: PropTypes.number,
+  cy: PropTypes.number,
+  midAngle: PropTypes.number,
+  outerRadius: PropTypes.number,
+  fill: PropTypes.string,
+  percent: PropTypes.number
+};
 
 const SectionPieChart = ({ data, style, dimensions, legend, chartProperties = {}, legendStyle = {}, sortBy }) => {
   const dataMap = {};
@@ -73,9 +104,9 @@ const SectionPieChart = ({ data, style, dimensions, legend, chartProperties = {}
                 endAngle={chartProperties.endAngle || -270}
                 outerRadius={outerRadius > 10 ? outerRadius - 5 : outerRadius}
                 innerRadius={innerRadius > 10 ? innerRadius - 5 : innerRadius}
-                labelLine={chartProperties.labelLine}
+                labelLine={false}
                 dataKey="value"
-                label={chartProperties.label || { offsetRadius: 1 }}
+                label={chartProperties.label || CustomizedPieLabel}
               >
                 {/* // creating links to urls according the 'url' filed in the data */}
                 {preparedData.map((entry) => {

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -58,3 +58,5 @@ export const GRID_LAYOUT_COLUMNS = 12;
 export const CHART_LEGEND_ITEM_HEIGHT = 26;
 
 export const NONE_VALUE_DEFAULT_NAME = 'None';
+
+export const RADIANS = Math.PI / 180;

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -4,6 +4,7 @@ import { prepareSections } from '../../src/utils/reports';
 import ReportContainer from '../../src/containers/ReportContainer';
 import ChartLegend from '../../src/components/Sections/SectionChart/ChartLegend';
 import ReportLayout from '../../src/components/Layouts/ReportLayout';
+import { CustomizedPieLabel } from '../../src/components/Sections/SectionChart/SectionPieChart';
 import { SectionHeader, SectionText, SectionDate, SectionChart, SectionTable, SectionImage, SectionDivider,
   SectionMarkdown, SectionJson, SectionNumber, SectionDuration } from '../../src/components/Sections';
 import { BarChart, PieChart, Pie, LineChart } from 'recharts';
@@ -282,6 +283,8 @@ describe('Report Container', () => {
 
     expect(pieChart.props().width).to.equal(sec5.layout.dimensions.width);
     expect(pie.props().data.length).to.equal(sec5.data.length);
+    const labels = reportContainer.find(CustomizedPieLabel);
+    expect(labels).to.have.length(sec5.data.length);
 
     expect(barChart.at(0).props().width).to.equal(sec1.layout.dimensions.width);
     expect(barChart.at(0).props().height).to.equal(sec1.layout.dimensions.height);

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -4,7 +4,6 @@ import { prepareSections } from '../../src/utils/reports';
 import ReportContainer from '../../src/containers/ReportContainer';
 import ChartLegend from '../../src/components/Sections/SectionChart/ChartLegend';
 import ReportLayout from '../../src/components/Layouts/ReportLayout';
-import { CustomizedPieLabel } from '../../src/components/Sections/SectionChart/SectionPieChart';
 import { SectionHeader, SectionText, SectionDate, SectionChart, SectionTable, SectionImage, SectionDivider,
   SectionMarkdown, SectionJson, SectionNumber, SectionDuration } from '../../src/components/Sections';
 import { BarChart, PieChart, Pie, LineChart } from 'recharts';
@@ -283,8 +282,6 @@ describe('Report Container', () => {
 
     expect(pieChart.props().width).to.equal(sec5.layout.dimensions.width);
     expect(pie.props().data.length).to.equal(sec5.data.length);
-    const labels = reportContainer.find(CustomizedPieLabel);
-    expect(labels).to.have.length(sec5.data.length);
 
     expect(barChart.at(0).props().width).to.equal(sec1.layout.dimensions.width);
     expect(barChart.at(0).props().height).to.equal(sec1.layout.dimensions.height);


### PR DESCRIPTION
fixed sometimes data in table is a complex object instead of array causing miscalculation of the rows.
fixes demisto/etc#13103

example:
![image](https://user-images.githubusercontent.com/18641362/45632024-03261e00-baa5-11e8-920d-692f5302f9d5.png)
