### PR TITLE
fix postcss-cssnext cause build failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "npm-check-updates": "2.12.1",
     "phantomjs-prebuilt": "2.1.14",
     "postcss": "6.0.8",
-    "postcss-cssnext": "3.0.2",
+    "postcss-cssnext": "3.1.0",
     "postcss-import": "10.0.0",
     "postcss-loader": "2.0.6",
     "postcss-url": "7.1.1",


### PR DESCRIPTION
fix `node[38289]: ../src/node_file.cc:943:void node::fs::Stat(const FunctionCallbackInfo<v8::Value> &): Assertion (argc) == (4)' failed...` on `npm run production`