### PR TITLE
table report fix + text field wrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "generate-report": "./reportsServer-macos templates/test.json",
     "devtools": "DEV_TOOLS=1 npm start",
     "lint": "eslint src tests",
-    "make": "cd reportService && npm run build",
+    "make": "cd reportService && npm install && npm run build",
     "test": "NODE_ENV=test istanbul cover ./node_modules/.bin/_mocha -- tests -R spec --compilers js:babel-core/register,css:null-compiler.js --require ./tests/helpers/helper.js --recursive --check-leaks",
     "test-no-cover": "NODE_ENV=test mocha tests -R spec --compilers js:babel-core/register,css:null-compiler.js --require ./tests/helpers/helper.js --recursive --check-leaks",
     "coverage": "NODE_ENV=test istanbul cover ./node_modules/.bin/_mocha --report lcovonly -- tests -R spec --compilers js:babel-core/register,css:null-compiler.js --require ./tests/helpers/helper.js --recursive --check-leaks && cat ./coverage/lcov.info | COVERALLS_SERVICE_NAME=circle-ci COVERALLS_REPO_TOKEN=BpaCDz1aFLckIylCx4YIG6uiu1xXU0r66 ./node_modules/coveralls/bin/coveralls.js",

--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -18,7 +18,7 @@ function getGridItemFromSection(section, overflowRows) {
   const rows = section.layout.rowPos + overflowRows;
   let height = section.layout.h;
   if (section.type === SECTION_TYPES.table && section.layout.w >= GRID_LAYOUT_COLUMNS) {
-    const numOfRows = ((section.data.length || section.data.total) + 1) * 0.66;
+    const numOfRows = (section.data.length || section.data.total) + 1;
     if (numOfRows > section.layout.h) {
       height = numOfRows;
     }

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -41,10 +41,13 @@ h1 {
       background-color: #ebebec;
     }
   }
-  .react-grid-item {
-    overflow: hidden;
-    transition: none;
-    z-index: 1;
-    height: auto !important;
+  .react-grid-layout {
+    height: auto !important; // override grid height
+    .react-grid-item {
+      overflow: hidden;
+      transition: none;
+      z-index: 1;
+      height: auto !important; // override grid item height to fit content
+    }
   }
 }

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -45,5 +45,6 @@ h1 {
     overflow: hidden;
     transition: none;
     z-index: 1;
+    height: auto !important;
   }
 }

--- a/src/components/Sections/SectionText.less
+++ b/src/components/Sections/SectionText.less
@@ -1,3 +1,5 @@
 .section-text {
   white-space: pre-wrap;
+  hyphens: auto;
+  word-break: break-word;
 }


### PR DESCRIPTION
fix text fields does not wrap on long spaceless text.
added npm install to service make
fix table height create empty pages

