### PR TITLE
fix number widget position after height changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
     "webpack": "3.4.1",
     "webpack-cli": "3.2.1",
     "webpack-dev-middleware": "1.11.0",
-    "webpack-dev-server": "3.1.14",
+    "webpack-dev-server": "2.9.1",
     "webpack-hot-middleware": "2.18.2",
     "webpack-livereload-plugin": "0.11.0"
   }

--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -246,7 +246,7 @@ const ReportLayout = ({ sections, headerLeftImage, headerRightImage, isLayout })
                             return (
                               <div
                                 key={section.layout.i}
-                                className={section.layout.class}
+                                className={`section-${section.type} ${section.layout.class || ''}`}
                                 style={section.layout.sectionStyle}
                                 data-grid={gridItem}
                               >

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -47,7 +47,7 @@ h1 {
       overflow: hidden;
       transition: none;
       z-index: 1;
-      .section-table {
+      &.section-table {
         height: auto !important; // override grid item height to fit content
       }
     }

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -47,7 +47,9 @@ h1 {
       overflow: hidden;
       transition: none;
       z-index: 1;
-      height: auto !important; // override grid item height to fit content
+      .section-table {
+        height: auto !important; // override grid item height to fit content
+      }
     }
   }
 }


### PR DESCRIPTION
use `webpack-dev-server` stable version (https://github.com/webpack/webpack-dev-server/issues/1355#issuecomment-406541618)
fix widget number not showing regression

![image](https://user-images.githubusercontent.com/18641362/53695434-73f79300-3dc4-11e9-98e8-1ec71b44c384.png)


