### PR TITLE
Chart overlap fix, list section custom column support, phatomJS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,8 @@
   "dependencies": {
     "babel-runtime": "6.25.0",
     "classnames": "2.2.5",
+    "core-js": "3.1.4",
+    "create-react-class": "15.6.3",
     "jquery": "3.4.0",
     "less": "2.7.2",
     "markdown-it-abbr": "1.0.4",

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -7,6 +7,7 @@ import { isArray, orderBy, unionBy } from 'lodash';
 import { sortStrings } from '../../../utils/strings';
 import { getGraphColorByName } from '../../../utils/colors';
 import { CHART_LAYOUT_TYPE, NONE_VALUE_DEFAULT_NAME } from '../../../constants/Constants';
+import { AutoSizer } from 'react-virtualized';
 
 const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {},
   legendStyle = null, sortBy, stacked }) => {
@@ -107,43 +108,52 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
 
   return (
     <div className={mainClass} style={style}>
-      <BarChart
-        width={dimensions.width}
-        height={dimensions.height}
-        data={preparedData}
-        layout={chartProperties.layout}
-        margin={margin}
-        barSize={chartProperties.barSize || 13}
-      >
-        {chartProperties.layout === CHART_LAYOUT_TYPE.vertical &&
-          <YAxis hide={!stacked} tick={{ fontSize: '15px' }} interval={0} dataKey="name" type="category" />}
-        {chartProperties.layout === CHART_LAYOUT_TYPE.vertical && <XAxis type="number" allowDecimals={false} />}
-        {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <YAxis type="number" />}
-        {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <XAxis tick dataKey="name" type="category" />}
-        <CartesianGrid strokeDasharray={chartProperties.strokeDasharray || '3 3'} />
-        <Tooltip />
-        {legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend &&
-          <Legend
-            content={<ChartLegend
-              data={dataItems}
-              valueDisplay={VALUE_FORMAT_TYPES.minimal}
-              showValue={!isColumnChart && !stacked}
-              icon={legendStyle.iconType}
-              layout={legendStyle.layout}
-              style={legendStyle && legendStyle.style}
-            />}
-            {...legendStyle}
-          />
+      <AutoSizer>
+        {({ width, height }) => {
+          return (<BarChart
+            width={width || dimensions.width}
+            height={height || dimensions.height}
+            data={preparedData}
+            layout={chartProperties.layout}
+            margin={margin}
+            barSize={chartProperties.barSize || 13}
+          >
+            {chartProperties.layout === CHART_LAYOUT_TYPE.vertical &&
+              <YAxis hide={!stacked} tick={{ fontSize: '15px' }} interval={0} dataKey="name" type="category" />}
+            {chartProperties.layout === CHART_LAYOUT_TYPE.vertical && <XAxis type="number" allowDecimals={false} />}
+            {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <YAxis type="number" />}
+            {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <XAxis tick dataKey="name" type="category" />}
+            <CartesianGrid strokeDasharray={chartProperties.strokeDasharray || '3 3'} />
+            <Tooltip />
+            {legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend &&
+              <Legend
+                content={<ChartLegend
+                  data={dataItems}
+                  valueDisplay={VALUE_FORMAT_TYPES.minimal}
+                  showValue={!isColumnChart && !stacked}
+                  icon={legendStyle.iconType}
+                  layout={legendStyle.layout}
+                  style={legendStyle && legendStyle.style}
+                />}
+                {...legendStyle}
+              />
+            }
+            {dataItems.map((item) => <Bar
+              key={item.name}
+              dataKey={item.name}
+              stackId="stack"
+              fill={item.color}
+              onClick={(e) => {
+                if (e.url) {
+                  window.open(e.url, '_blank');
+                }
+              }}
+              label={!!chartProperties.label}
+            />)}
+          </BarChart>);
         }
-        {dataItems.map((item) => <Bar
-          key={item.name}
-          dataKey={item.name}
-          stackId="stack"
-          fill={item.color}
-          onClick={(e) => { if (e.url) { window.open(e.url, '_blank'); } }}
-          label={!!chartProperties.label}
-        />)}
-      </BarChart>
+        }
+      </AutoSizer>
     </div>
   );
 };

--- a/src/components/Sections/SectionChart/SectionBarChart.less
+++ b/src/components/Sections/SectionChart/SectionBarChart.less
@@ -1,4 +1,5 @@
 .section-bar-chart {
+  height: 100%;
   line {
     display: none;
   }
@@ -9,6 +10,7 @@
   }
 }
 .section-column-chart {
+  height: 100%;
   .recharts-legend-wrapper {
     right: 0 !important;
   }

--- a/src/components/Sections/SectionChart/SectionChart.js
+++ b/src/components/Sections/SectionChart/SectionChart.js
@@ -11,6 +11,7 @@ const SectionChart = ({ type, data, style, dimensions, legend, chartProperties =
         referenceLineX, referenceLineY, title, stacked, fromDate, toDate, titleStyle }) =>
   <div className="section-chart" style={style}>
     {title && <div className="section-title" style={titleStyle}>{title}</div>}
+    <div className="section-chart-content">
     {
       (() => {
         let chartToRender;
@@ -66,6 +67,7 @@ const SectionChart = ({ type, data, style, dimensions, legend, chartProperties =
         return chartToRender;
       })()
     }
+    </div>
   </div>
 ;
 SectionChart.propTypes = {

--- a/src/components/Sections/SectionChart/SectionChart.less
+++ b/src/components/Sections/SectionChart/SectionChart.less
@@ -1,8 +1,15 @@
 @import (reference) "../../../css/variables";
 
 .section-chart {
+  height: 100%;
+  width: 100%;
+  display: table;
   .section-title {
     font-size: 18px;
     margin: 10px 0;
+    display: table-row;
+  }
+  .section-chart-content {
+    display: table-row;
   }
 }

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { LineChart, Line, XAxis, YAxis, ReferenceLine, CartesianGrid, Tooltip, Legend } from 'recharts';
 import ChartLegend from './ChartLegend';
 import { compact, values } from 'lodash';
+import { AutoSizer } from 'react-virtualized';
 import moment from 'moment';
 import { QUERIES_TIME_FORMAT, SUPPORTED_TIME_FRAMES } from '../../../constants/Constants';
 import { sortStrings } from '../../../utils/strings';
@@ -107,55 +108,60 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
 
   return (
     <div className="section-line-chart" style={style}>
-      <LineChart
-        width={dimensions.width}
-        height={dimensions.height}
-        data={preparedData}
-        margin={chartProperties.margin}
-      >
-        {(referenceLineX || chartProperties.layout === 'vertical') &&
-          [<XAxis
-            dataKey="name"
-            key="x"
-            interval="preserveStartEnd"
-          />,
-            <YAxis key="y" domain={[0, dataMax => dataMax + Math.ceil(dataMax * 0.33)]} />
-          ]
+      <AutoSizer>
+        {({ width, height }) => {
+          return (<LineChart
+            width={width || dimensions.width}
+            height={height || dimensions.height}
+            data={preparedData}
+            margin={chartProperties.margin}
+          >
+            {(referenceLineX || chartProperties.layout === 'vertical') &&
+            [<XAxis
+              dataKey="name"
+              key="x"
+              interval="preserveStartEnd"
+            />,
+              <YAxis key="y" domain={[0, dataMax => dataMax + Math.ceil(dataMax * 0.33)]} />
+            ]
+            }
+            {(referenceLineY || chartProperties.layout === 'horizontal') && <YAxis dataKey="name" />}
+            <CartesianGrid
+              strokeDasharray={chartProperties.strokeDasharray || '4 4'}
+              fill={chartProperties.chartFill || '#000000'}
+              vertical={false}
+              fillOpacity={chartProperties.chartFillOpacity || 0.04}
+            />
+            <Tooltip />
+            {referenceLineX &&
+              <ReferenceLine x={referenceLineX.x} stroke={referenceLineX.stroke} label={referenceLineX.label} />}
+            {referenceLineY &&
+              <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke} label={referenceLineY.label} />}
+            {legendStyle && !legendStyle.hideLegend &&
+              <Legend
+                content={<ChartLegend
+                  icon="square"
+                  data={preparedLegend}
+                  style={legendStyle && legendStyle.style}
+                />}
+                {...legendStyle}
+              />
+            }
+            {preparedLegend.map((item) =>
+              <Line
+                key={item.name}
+                dataKey={item.name}
+                type="monotone"
+                stroke={item.color}
+                animationDuration={0}
+                activeDot={{ strokeWidth: 0 }}
+                strokeWidth={3}
+                dot={false}
+              />)}
+          </LineChart>);
         }
-        {(referenceLineY || chartProperties.layout === 'horizontal') && <YAxis dataKey="name" />}
-        <CartesianGrid
-          strokeDasharray={chartProperties.strokeDasharray || '4 4'}
-          fill={chartProperties.chartFill || '#000000'}
-          vertical={false}
-          fillOpacity={chartProperties.chartFillOpacity || 0.04}
-        />
-        <Tooltip />
-        {referenceLineX &&
-          <ReferenceLine x={referenceLineX.x} stroke={referenceLineX.stroke} label={referenceLineX.label} />}
-        {referenceLineY &&
-          <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke} label={referenceLineY.label} />}
-        {legendStyle && !legendStyle.hideLegend &&
-          <Legend
-            content={<ChartLegend
-              icon="square"
-              data={preparedLegend}
-              style={legendStyle && legendStyle.style}
-            />}
-            {...legendStyle}
-          />
         }
-        {preparedLegend.map((item) =>
-          <Line
-            key={item.name}
-            dataKey={item.name}
-            type="monotone"
-            stroke={item.color}
-            animationDuration={0}
-            activeDot={{ strokeWidth: 0 }}
-            strokeWidth={3}
-            dot={false}
-          />)}
-      </LineChart>
+      </AutoSizer>
     </div>
   );
 };

--- a/src/components/Sections/SectionChart/SectionLineChart.less
+++ b/src/components/Sections/SectionChart/SectionLineChart.less
@@ -1,4 +1,5 @@
 .section-line-chart {
+  height: 100%;
   .recharts-legend-wrapper {
     left: 0 !important;
     width: 100% !important;

--- a/src/components/Sections/SectionChart/SectionPieChart.less
+++ b/src/components/Sections/SectionChart/SectionPieChart.less
@@ -1,4 +1,5 @@
 .section-pie-chart {
+  height: 100%;
   .customized-legend {
     padding: 10px 0;
   }

--- a/src/components/Sections/SectionList.js
+++ b/src/components/Sections/SectionList.js
@@ -1,6 +1,7 @@
+import './SectionList.less';
 import React from 'react';
 import PropTypes from 'prop-types';
-import isString from 'lodash/isString';
+import { isString, isEmpty, isObject } from 'lodash';
 import moment from 'moment';
 
 function getFieldValue(fieldName, dataItem) {
@@ -47,10 +48,16 @@ const SectionList = ({ columns, data, classes, style, title, titleStyle }) => {
     <div className={mainClass} style={style}>
       {title && <div className="section-title" style={titleStyle}>{title}</div>}
       {tableData.map((item) => {
-        const leftName = columns[0] ? columns[0].key : 'name';
+        let leftName = 'name';
+        if (!isEmpty(columns)) {
+          leftName = (isObject(columns[0]) ? columns[0].key : columns[0]) || leftName;
+        }
         const mainKeyValue = getFieldValue(leftName, item);
 
-        const rightName = columns[1] ? columns[1].key : 'value';
+        let rightName = 'value';
+        if (!isEmpty(columns) && columns.length > 1) {
+          rightName = (isObject(columns[1]) ? columns[1].key : columns[1]) || rightName;
+        }
         const rightValue = getFieldValue(rightName, item);
 
         const id = getFieldValue('id', item);

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ import $ from 'jquery';
 window.jQuery = $; // Assure it's available globally.
 require('semantic-ui/dist/semantic.min.js'); // eslint-disable-line
 import './css/Index.css';
+import 'core-js';
 
 import React from 'react';
 import ReactDOM from 'react-dom';


### PR DESCRIPTION
- fixed height miss-render on charts
- fixed list section should accept column strings as well as objects
- added support for phantomJS using `core-js` including es6 to support backward compatibility