### PR TITLE
round date chart difference fix partial dates

### DIFF
--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -68,7 +68,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
   }));
 
   const retData = [];
-  const frames = finalToDate.diff(from, timeFrame);
+  const frames = Math.ceil(finalToDate.diff(from, timeFrame, true));
   const currentDate = moment(from);
   for (let i = 0; i <= frames; i++) {
     const formattedDate = currentDate.format(timeFormat);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/18641362/62011878-389c9d00-b187-11e9-9a8b-92cf56d83142.png)
![image](https://user-images.githubusercontent.com/18641362/62011888-608c0080-b187-11e9-8916-3dec527f4dc3.png)

diff between dates should always ceil to highest difference to count frames.