### PR TITLE
Handle big size reports & table fixes

### DIFF
--- a/reportService/package.json
+++ b/reportService/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "clean": "rm -rf ../reportsServer ../reportsServer-mac",
-    "build": "./node_modules/.bin/pkg . --out-path .. && mv ../reportsServer-linux ../reportsServer",
+    "build": "./node_modules/.bin/pkg . --options max_old_space_size=4096 --out-path .. && mv ../reportsServer-linux ../reportsServer",
     "build-mac": "npm run clean && ./node_modules/.bin/pkg . -t mac --out-path .."
   },
   "pre-commit": [

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -126,6 +126,7 @@ const PAGE_MARGIN = 60;
 
     console.log('output ' + outputFinal);
     await page.setViewport({width: dimensions.width, height: dimensions.height});
+    await page.setDefaultNavigationTimeout(0);
     await page.goto('file://' + baseUrl + '/' + tmpReportName, {waitUntil: 'networkidle0'});
     await page.emulateMedia('screen');
     await page._client.send('Emulation.clearDeviceMetricsOverride');

--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -43,8 +43,8 @@ class ReportLayout extends Component {
     return { w: section.layout.w, h: height, y: rows, x: section.layout.columnPos || 0, i: section.layout.i };
   }
 
-  static getElementBySection(section) {
-    let sectionToRender = getSectionComponent(section);
+  static getElementBySection(section, maxWidth) {
+    let sectionToRender = getSectionComponent(section, maxWidth);
     if (ReportLayout.isPageBreakSection(section)) {
       sectionToRender = (
         <div>
@@ -97,7 +97,7 @@ class ReportLayout extends Component {
   }
 
   render() {
-    const { sections, headerLeftImage, headerRightImage, isLayout } = this.props;
+    const { sections, headerLeftImage, headerRightImage, isLayout, dimensions } = this.props;
     return (
       <div className="report-layout">
         <span className="hidden-header" style={{ display: 'none' }}>
@@ -128,7 +128,7 @@ class ReportLayout extends Component {
                         >
                           {
                             (() => {
-                              return ReportLayout.getElementBySection(section);
+                              return ReportLayout.getElementBySection(section, dimensions && dimensions.width);
                             })()
                           }
                         </div>

--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -9,7 +9,7 @@ import truncate from 'lodash/truncate';
 import isObjectLike from 'lodash/isObjectLike';
 
 
-const SectionTable = ({ columns, readableHeaders, data, classes, style, title, titleStyle, emptyString }) => {
+const SectionTable = ({ columns, readableHeaders, data, classes, style, title, titleStyle, emptyString, maxColumns }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -38,9 +38,9 @@ const SectionTable = ({ columns, readableHeaders, data, classes, style, title, t
     readyColumns = Object.keys(headerKeys);
   }
 
-
   let tableBody;
   if (isArray(readyColumns)) {
+    readyColumns = maxColumns > 0 ? readyColumns.slice(0, maxColumns) : readyColumns;
     tableBody = tableData.length > 0 ? (
       <table className={'ui compact table unstackable section-table ' + classes} style={{ tableLayout: 'fixed' }}>
         <thead>
@@ -76,7 +76,7 @@ const SectionTable = ({ columns, readableHeaders, data, classes, style, title, t
                         cellToRender = truncate(cell, { length: DEFAULT_MAX_LENGTH });
                     }
                   }
-                  return <td key={j} style={{ wordBreak: 'break-word', whiteSpace: 'pre' }}>{cellToRender}</td>;
+                  return <td key={j} style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'normal' }}>{cellToRender}</td>;
                 })()
               )}
             </tr>)
@@ -119,6 +119,7 @@ SectionTable.propTypes = {
   classes: PropTypes.string,
   style: PropTypes.object,
   title: PropTypes.string,
+  maxColumns: PropTypes.number,
   titleStyle: PropTypes.object,
   emptyString: PropTypes.string
 };

--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -9,7 +9,8 @@ import truncate from 'lodash/truncate';
 import isObjectLike from 'lodash/isObjectLike';
 
 
-const SectionTable = ({ columns, readableHeaders, data, classes, style, title, titleStyle, emptyString, maxColumns }) => {
+const SectionTable = ({ columns, readableHeaders, data, classes, style, title, titleStyle, emptyString,
+  maxColumns }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -76,7 +77,11 @@ const SectionTable = ({ columns, readableHeaders, data, classes, style, title, t
                         cellToRender = truncate(cell, { length: DEFAULT_MAX_LENGTH });
                     }
                   }
-                  return <td key={j} style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'normal' }}>{cellToRender}</td>;
+                  return (
+                    <td key={j} style={{ wordBreak: 'break-all', wordWrap: 'break-word', whiteSpace: 'normal' }}>
+                      {cellToRender}
+                    </td>
+                  );
                 })()
               )}
             </tr>)

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -23,7 +23,7 @@ function getDefaultEmptyNotification() {
   return 'No results found.';
 }
 
-export function getSectionComponent(section) {
+export function getSectionComponent(section, maxWidth) {
   let sectionToRender;
   switch (section.type) {
     case SECTION_TYPES.header:
@@ -172,6 +172,7 @@ export function getSectionComponent(section) {
           style={section.layout.style}
           titleStyle={section.titleStyle}
           title={section.title}
+          maxColumns={section.layout.maxColumns || (maxWidth ? maxWidth / 100 : 0)}
           emptyString={section.emptyNotification || getDefaultEmptyNotification()}
         />
       );


### PR DESCRIPTION
- use reports service with extra memory and no navigation timeout for big reports
- added max columns for section table which defaults to the max columns possible under the page size
- fixed table line breaks not working when only one word

fixes: https://github.com/demisto/etc/issues/19600