### PR TITLE
remove force font family on all elements

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -1,9 +1,5 @@
 @import (reference) "../../css/variables";
 
-* {
-  font-family: @font-family-base;
-}
-
 body {
   color: @font-color-base;
   font-family: @font-family-base !important;


### PR DESCRIPTION
remove force font family and force on body only. This will be overridden by any style given to section/items (since it apply it directly on the element with higher priority).

fixes https://github.com/demisto/sane-reports/issues/83

```
[{
  "type": "html",
  "data": "<span style=\"font-family:Arial\">hello <strong>bold</strong> hello</span>",
  "layout": {
    "rowPos": 8200,
    "columnPos": 100,
    "tableClasses": "right aligned",
    "style": {
      "color": "#555555",
      "fontSize": 14,
      "backgroundColor": "#ffffff",
      "padding": 6,
      "border": "1px solid #d4d4d4",
      "marginTop": -9
    }
  }
},
  {
    "type": "markdown",
    "data": "hello **bold** hello",
    "layout": {
      "rowPos": 8200,
      "columnPos": 100,
      "tableClasses": "right aligned",
      "style": {
        "color": "#555555",
        "fontSize": 14,
        "fontFamily": "Arial",
        "backgroundColor": "#ffffff",
        "padding": 6,
        "border": "1px solid #d4d4d4",
        "marginTop": -9
      }
    }
  }]
```
![image](https://user-images.githubusercontent.com/18641362/67800422-e32aa180-fa8f-11e9-89e4-0d1672ab5a6d.png)
