### PR TITLE
Fix non latin letters not appearing in some cases + chart legend capitalization

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8">
+  </head>
   <script>
     var headerLeftImage = '{report-header-image-left}';
     var headerRightImage = '{report-header-image-right}';
@@ -8,9 +11,6 @@
     var reportData = '{report-data-to-replace}';
     var forceAutoHeightLayout = '{force-auto-height}';
   </script>
-  <head>
-    <meta charset="utf-8">
-  </head>
   <body>
     <div id="app"></div>
   </body>

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -16,6 +16,10 @@ h1 {
   font-family: @font-family-base !important;
 }
 
+.capitalize {
+  text-transform: capitalize;
+}
+
 .global-section {
   .global-section-row {
     display: flex;

--- a/src/components/Sections/SectionChart/ChartLegend.js
+++ b/src/components/Sections/SectionChart/ChartLegend.js
@@ -11,7 +11,7 @@ import { values } from 'lodash';
 export const VALUE_FORMAT_TYPES = { minimal: 'minimal', stretch: 'stretch' };
 const DIGIT_PIXEL_SIZE = 8;
 const ICON_CONTAINER_PIXEL_SIZE = 25;
-const ChartLegend = ({ data, icon = 'circle', layout = CHART_LAYOUT_TYPE.vertical, height,
+const ChartLegend = ({ data, icon = 'circle', layout = CHART_LAYOUT_TYPE.vertical, height, capitalize,
   onClick, style, showValue = true, valueDisplay = VALUE_FORMAT_TYPES.stretch }) => {
   let legendData = data || [];
   if (legendData.length === 0) {
@@ -43,7 +43,7 @@ const ChartLegend = ({ data, icon = 'circle', layout = CHART_LAYOUT_TYPE.vertica
         <div className="recharts-legend-icon-container">
           <i className={legendIconClass} style={{ color: group.fill || group.color || group.stroke }} />
         </div>
-        <span className="recharts-legend-item-text" style={{ width }} onClick={onClick}>
+        <span className={classNames('recharts-legend-item-text', { capitalize })} style={{ width }} onClick={onClick}>
           {group.name}
         </span>
         {showValue && value &&
@@ -67,6 +67,7 @@ ChartLegend.propTypes = {
   data: PropTypes.array,
   icon: PropTypes.string,
   showValue: PropTypes.bool,
+  capitalize: PropTypes.bool,
   valueDisplay: PropTypes.oneOf(values(VALUE_FORMAT_TYPES)),
   layout: PropTypes.oneOf(values(CHART_LAYOUT_TYPE)),
   height: PropTypes.number,

--- a/src/components/Sections/SectionChart/ChartLegend.less
+++ b/src/components/Sections/SectionChart/ChartLegend.less
@@ -32,9 +32,6 @@
     }
     .recharts-legend-item-text {
       display: inline-block;
-      &.capitalize {
-        text-transform: capitalize;
-      }
     }
     .recharts-legend-item-value {
       float: right;

--- a/src/components/Sections/SectionChart/ChartLegend.less
+++ b/src/components/Sections/SectionChart/ChartLegend.less
@@ -32,6 +32,9 @@
     }
     .recharts-legend-item-text {
       display: inline-block;
+      &.capitalize {
+        text-transform: capitalize;
+      }
     }
     .recharts-legend-item-value {
       float: right;

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -133,6 +133,7 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
                     valueDisplay={VALUE_FORMAT_TYPES.minimal}
                     showValue={!isColumnChart && !stacked}
                     icon={legendStyle.iconType}
+                    capitalize={legendStyle.capitalize === undefined || legendStyle.capitalize}
                     layout={legendStyle.layout}
                     style={legendStyle && legendStyle.style}
                   />}

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -142,6 +142,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                   content={<ChartLegend
                     icon="square"
                     data={preparedLegend}
+                    capitalize={legendStyle.capitalize === undefined || legendStyle.capitalize}
                     style={legendStyle && legendStyle.style}
                   />}
                   {...legendStyle}

--- a/src/components/Sections/SectionChart/SectionPieChart.js
+++ b/src/components/Sections/SectionChart/SectionPieChart.js
@@ -133,6 +133,7 @@ const SectionPieChart = ({ data, style, dimensions, legend, chartProperties = {}
                 content={
                   <ChartLegend
                     iconType="circle"
+                    capitalize={legendStyle.capitalize === undefined || legendStyle.capitalize}
                     data={preparedData}
                     height={legendHeight}
                     style={legendStyle && legendStyle.style}

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -377,6 +377,7 @@
       "legendStyle": {
         "align": "center",
         "iconSize": 8,
+        "capitalize": false,
         "iconType": "square",
         "verticalAlign": "top",
         "width": 772,

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -388,5 +388,7 @@ describe('Report Container', () => {
     const chartLegend = reportContainer.find(ChartLegend);
     expect(chartLegend).to.have.length(4);
     expect(chartLegend.at(0).props().style).to.be.equal(sec1.layout.legendStyle.style);
+    expect(chartLegend.at(0).props().capitalize).to.be.true;
+    expect(chartLegend.at(3).props().capitalize).to.be.false;
   });
 });


### PR DESCRIPTION
- added automatic capitalize on chart legends with capitalize option in legendstyle
```
"legendStyle": {
        "capitalize": false
}
```
defaults to true if not specified

- fixed non-latin letters did not resolve if embedded data was too big
![image](https://user-images.githubusercontent.com/18641362/68782124-214fc580-0639-11ea-8d25-b9427c94ecfd.png)
