### PR TITLE
Page break calculations fixes + markdown section oveflow bounds

### DIFF
--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -65,8 +65,7 @@ class ReportLayout extends Component {
     setTimeout(() => {
       // set dynamic height for all sections, fix top attribute.
       const itemsByRow = groupBy(Object.values(this.itemElements), item => item.gridItem.y);
-      let pageOffset = 0;
-      let heightMap = {};
+      const heightMap = {};
       Object.keys(itemsByRow).sort(compareFields).forEach((key) => {
         const items = itemsByRow[key];
         let shouldPageBreak = false;
@@ -83,7 +82,7 @@ class ReportLayout extends Component {
         if (dimensions && dimensions.height > 0 && shouldPageBreak) {
           for (let i = 0; i < GRID_LAYOUT_COLUMNS; i++) {
             const accumulatedHeight = heightMap[i] || 0;
-            pageOffset = dimensions.height - (accumulatedHeight % dimensions.height);
+            const pageOffset = dimensions.height - (accumulatedHeight % dimensions.height);
             heightMap[i] = accumulatedHeight + pageOffset;
           }
         }

--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -14,7 +14,9 @@ import ReactGridLayout from 'react-grid-layout';
 import { compareFields } from '../../utils/sort';
 import ErrorBoundary from '../ErrorBoundary';
 import { getSectionComponent } from '../../utils/layout';
+
 const ROW_PIXEL_HEIGHT = 110;
+const SECTION_HEIGHT_TOTAL_PADDING = 20;
 
 class ReportLayout extends Component {
   static propTypes = {
@@ -73,7 +75,8 @@ class ReportLayout extends Component {
           if (item.element) {
             item.element.style.top = `${heightMap[item.gridItem.x]}px`;
             for (let i = item.gridItem.x; i < item.gridItem.x + item.gridItem.w; i++) {
-              heightMap[i] = heightMap[i] ? heightMap[i] + 20 + item.element.clientHeight : item.element.clientHeight;
+              heightMap[i] = heightMap[i] ? heightMap[i] + SECTION_HEIGHT_TOTAL_PADDING
+                + item.element.clientHeight : item.element.clientHeight;
             }
             shouldPageBreak = shouldPageBreak || ReportLayout.isPageBreakSection(item.section);
           }

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -26,6 +26,7 @@ h1 {
     flex-direction: row;
     .subsection-wrapper {
       flex: 1;
+      width: 100%;
       .section-text {
         height: 100%;
       }

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -74,4 +74,5 @@ export const SECTION_ITEM_TYPE = {
 };
 
 export const PAGE_BREAK_KEY = '\\pagebreak';
+
 export const PIXEL_SIZE = 3.779527559055;

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -74,3 +74,4 @@ export const SECTION_ITEM_TYPE = {
 };
 
 export const PAGE_BREAK_KEY = '\\pagebreak';
+export const PIXEL_SIZE = 3.779527559055;

--- a/src/containers/ReportContainer.js
+++ b/src/containers/ReportContainer.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { ReportLayout } from '../components';
 
-const ReportContainer = ({ sections, headerLeftImage, headerRightImage, isLayout, dimensions, isAutoHeightLayout }) => {
+const ReportContainer = ({ sections, headerLeftImage, headerRightImage, isLayout, dimensions }) => {
   return (
     <ReportLayout
       sections={sections}
@@ -10,7 +10,6 @@ const ReportContainer = ({ sections, headerLeftImage, headerRightImage, isLayout
       headerLeftImage={headerLeftImage}
       headerRightImage={headerRightImage}
       dimensions={dimensions}
-      isAutoHeightLayout={isAutoHeightLayout}
     />
   );
 };
@@ -19,7 +18,6 @@ ReportContainer.propTypes = {
   headerLeftImage: PropTypes.string,
   headerRightImage: PropTypes.string,
   isLayout: PropTypes.bool,
-  isAutoHeightLayout: PropTypes.bool,
   dimensions: PropTypes.object
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReportContainer from './containers/ReportContainer';
 import * as TemplateProvider from '../templates/templateProvider';
-import { REPORT_DATA_TOKEN, REPORT_TYPES } from './constants/Constants';
+import { REPORT_DATA_TOKEN, REPORT_TYPES, PIXEL_SIZE } from './constants/Constants';
 import { prepareSections, getReportType } from './utils/reports';
 import { generateOfficeReport } from './office/OfficeReport';
 
@@ -33,10 +33,9 @@ let dimensions;
 try {
   dimensions = JSON.parse(reportDimensions);
 } catch (e) {
-  dimensions = undefined;
+  // use A4 by default
+  dimensions = { width: 210 * PIXEL_SIZE, height: 297 * PIXEL_SIZE };
 }
-
-const isAutoHeightLayout = forceAutoHeightLayout === 'true';
 
 if (type === REPORT_TYPES.pdf) {
   ReactDOM.render(
@@ -47,7 +46,6 @@ if (type === REPORT_TYPES.pdf) {
         headerLeftImage={headerLeftImage}
         headerRightImage={headerRightImage}
         dimensions={dimensions}
-        isAutoHeightLayout={isAutoHeightLayout}
       />
     </div>,
     document.getElementById('app')


### PR DESCRIPTION
- using column based page break to determine required page break and widget's offset in the layout dynamically, thus avoiding stacked widgets causing incorrect heights.
- removed isAutoHeightLayout flag no longer needed.
- added default page dimensions for debugging or when missing from api.

Tested with old reports, widgets layout, and investigation layout.