### PR TITLE
Fix automatic height layout issue + remove cartesian grid from column chart

### DIFF
--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -75,12 +75,11 @@ class ReportLayout extends Component {
           if (item.element) {
             let maxOffset = heightMap[item.gridItem.x];
             for (let i = item.gridItem.x + 1; i < item.gridItem.x + item.gridItem.w; i++) {
-              maxOffset = Math.max(maxOffset, heightMap[i] || 0);
+              maxOffset = Math.max(maxOffset, heightMap[i] || 0) || 0;
             }
             item.element.style.top = `${maxOffset}px`;
             for (let i = item.gridItem.x; i < item.gridItem.x + item.gridItem.w; i++) {
-              heightMap[i] = heightMap[i] ? heightMap[i] + SECTION_HEIGHT_TOTAL_PADDING
-                + item.element.clientHeight : item.element.clientHeight;
+              heightMap[i] = maxOffset + SECTION_HEIGHT_TOTAL_PADDING + item.element.clientHeight;
             }
             shouldPageBreak = shouldPageBreak || ReportLayout.isPageBreakSection(item.section);
           }

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -2,7 +2,7 @@ import './SectionBarChart.less';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ChartLegend, { VALUE_FORMAT_TYPES } from './ChartLegend';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, CartesianGrid } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from 'recharts';
 import { isArray, orderBy, unionBy } from 'lodash';
 import { sortStrings } from '../../../utils/strings';
 import { getGraphColorByName } from '../../../utils/colors';
@@ -127,7 +127,6 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
               {chartProperties.layout === CHART_LAYOUT_TYPE.vertical && <XAxis type="number" allowDecimals={false} />}
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <YAxis type="number" />}
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <XAxis tick dataKey="name" type="category" />}
-              <CartesianGrid strokeDasharray={chartProperties.strokeDasharray || '3 3'} />
               <Tooltip />
               {legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend &&
                 <Legend


### PR DESCRIPTION
fix layout holes may cause sections to misscaclculated their total height
removed cartesian grid from column chart

![image](https://user-images.githubusercontent.com/18641362/81087518-80b0d300-8f02-11ea-826c-2ce08da2a6e1.png)
![image](https://user-images.githubusercontent.com/18641362/81088170-47c52e00-8f03-11ea-89fb-e79d7140c942.png)
