### PR TITLE
section items height fixes and cosmetic changes 

### DIFF
--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -87,7 +87,7 @@ const PAGE_MARGIN = 60;
     const dimensions = getPageSizeByOrientation(pageSize, orientation);
 
     const topMargin = (headerLeftImage || headerRightImage) && !disableHeaders ? PAGE_MARGIN : 0;
-    const bottomMargin = PAGE_MARGIN;
+    const bottomMargin = PAGE_MARGIN - 10;
     const afterTypeReplace =
       indexHtml
         .replace('\'{report-type}\'', JSON.stringify(reportType))
@@ -112,8 +112,7 @@ const PAGE_MARGIN = 60;
     console.log(`Using "${chromeExecution}" execution.`);
 
     const args = ['--no-sandbox', '--disable-dev-shm-usage', '--disable-auto-reload'];
-    const chrome = { x: 0, y: 74 };   // comes from config in reality
-    args.push(`--window-size=${dimensions.width+chrome.x},${dimensions.height+chrome.y}`);
+    args.push(`--window-size=${dimensions.width},${dimensions.height}`);
     browser = await puppeteer.launch({
       executablePath: chromeExecution,
       headless: true,

--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -16,7 +16,7 @@ import ErrorBoundary from '../ErrorBoundary';
 import { getSectionComponent } from '../../utils/layout';
 
 const ROW_PIXEL_HEIGHT = 110;
-const SECTION_HEIGHT_TOTAL_PADDING = 20;
+const SECTION_HEIGHT_TOTAL_PADDING = 30;
 
 class ReportLayout extends Component {
   static propTypes = {
@@ -35,7 +35,7 @@ class ReportLayout extends Component {
   static getGridItemFromSection(section, overflowRows) {
     const rows = section.layout.rowPos + overflowRows;
     let height = section.layout.h;
-    if (section.type === SECTION_TYPES.table && section.layout.w >= GRID_LAYOUT_COLUMNS) {
+    if (section.type === SECTION_TYPES.table && section.layout.w >= GRID_LAYOUT_COLUMNS && section.data) {
       const numOfRows = (section.data.length || section.data.total) + 1;
       if (numOfRows > section.layout.h) {
         height = numOfRows;
@@ -77,9 +77,12 @@ class ReportLayout extends Component {
             for (let i = item.gridItem.x + 1; i < item.gridItem.x + item.gridItem.w; i++) {
               maxOffset = Math.max(maxOffset, heightMap[i] || 0) || 0;
             }
+            if ([SECTION_TYPES.image, SECTION_TYPES.logo, SECTION_TYPES.date].indexOf(item.section.type) < 0) {
+              maxOffset = maxOffset > 0 ? maxOffset + SECTION_HEIGHT_TOTAL_PADDING : maxOffset;
+            }
             item.element.style.top = `${maxOffset}px`;
             for (let i = item.gridItem.x; i < item.gridItem.x + item.gridItem.w; i++) {
-              heightMap[i] = maxOffset + SECTION_HEIGHT_TOTAL_PADDING + item.element.clientHeight;
+              heightMap[i] = maxOffset + item.element.clientHeight;
             }
             shouldPageBreak = shouldPageBreak || ReportLayout.isPageBreakSection(item.section);
           }
@@ -97,7 +100,7 @@ class ReportLayout extends Component {
       const readyDiv = document.createElement('div');
       readyDiv.id = 'ready-doc';
       document.getElementsByTagName('body')[0].appendChild(readyDiv);
-    }, 3000);
+    }, 5000);
   }
 
   render() {

--- a/src/components/Sections/ItemsSection.js
+++ b/src/components/Sections/ItemsSection.js
@@ -9,6 +9,7 @@ import uuid from 'uuid';
 import { sortByFieldsWithPriority } from '../../utils/sort';
 
 const DESCRIPTION_KEY = 'description';
+const SECTION_ITEM_PADDING = 5;
 
 class ItemsSection extends Component {
   static propTypes = {
@@ -40,11 +41,11 @@ class ItemsSection extends Component {
   }
 
   componentDidMount() {
-    setTimeout(() => this.setColumnUsage(this.props), 1000); // avoid rerender height changes
+    setTimeout(() => this.setColumnUsage(this.props), 100); // avoid rerender height changes
   }
 
   componentWillReceiveProps(nextProps) {
-    setTimeout(() => this.setColumnUsage(nextProps), 1000); // avoid rerender height changes
+    setTimeout(() => this.setColumnUsage(nextProps), 100); // avoid rerender height changes
   }
 
   getSectionItemKey(item) {
@@ -79,7 +80,8 @@ class ItemsSection extends Component {
       }
       // use maximum offset
       for (let i = 0; i < colSpan; i++) {
-        columnUsage[sectionItem.startCol + i][sectionItem.index].offset = maxOffset;
+        columnUsage[sectionItem.startCol + i][sectionItem.index].offset = maxOffset > 0 ?
+          maxOffset + SECTION_ITEM_PADDING : 0;
       }
     });
 
@@ -118,7 +120,7 @@ class ItemsSection extends Component {
               {description && (
                 <SectionMarkdown
                   text={description}
-                  className="section-description"
+                  customClass="section-description"
                   setRef={(itemElement) => {
                     if (!itemElement) {
                       return;

--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -5,7 +5,7 @@
   width: 100%;
   height: 100%;
   .section-description {
-    padding: 5px 10px;
+    padding: 0 6px 5px;
   }
   .section-item {
     display: flex;

--- a/src/components/Sections/SectionGroupedList.js
+++ b/src/components/Sections/SectionGroupedList.js
@@ -1,3 +1,4 @@
+import './SectionGroupedList.less';
 import React from 'react';
 import PropTypes from 'prop-types';
 import SectionList from './SectionList';

--- a/src/components/Sections/SectionGroupedList.less
+++ b/src/components/Sections/SectionGroupedList.less
@@ -1,0 +1,5 @@
+.section-grouped-list {
+  .group-item-name {
+    font-weight: bold;
+  }
+}

--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -28,6 +28,7 @@ export default class SectionMarkdown extends Component {
     text: PropTypes.string,
     style: PropTypes.object,
     setRef: PropTypes.any,
+    customClass: PropTypes.string,
     tableClasses: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.string
@@ -103,7 +104,7 @@ export default class SectionMarkdown extends Component {
 
         res = (
           <table
-            className={`ui very compact table celled fixed selectable ${tableClasses}`}
+            className={`ui very compact table celled fixed unstackable selectable ${tableClasses}`}
             style={{ tableLayout: 'fixed' }}
             key={Math.random()}
           >
@@ -153,7 +154,7 @@ export default class SectionMarkdown extends Component {
   }
 
   render() {
-    const { text, style, tableClasses, doNotShowEmoji, setRef } = this.props;
+    const { text, style, tableClasses, doNotShowEmoji, setRef, customClass } = this.props;
     let finalText = text;
     IGNORE_KEYS.forEach((s) => {
       finalText = (finalText || '').replace(s, '');
@@ -192,7 +193,7 @@ export default class SectionMarkdown extends Component {
     }
 
     return (
-      <div className="section-markdown" ref={setRef} style={style}>
+      <div className={`section-markdown ${customClass || ''}`} ref={setRef} style={style}>
         {res}
       </div>
     );

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -38,9 +38,9 @@
 
 /** Layout **/
 @content-margin-top:                    0;
-@content-margin-right:                  10px;
+@content-margin-right:                  0.5in;
 @content-margin-bottom:                 0;
-@content-margin-left:                   10px;
+@content-margin-left:                   0.5in;
 
 /** colors **/
 @main-background-color:                 #fcfcfc;

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -661,7 +661,7 @@
         "fieldType": "",
         "data": "flgdfkjgg ksdf;ajlgdsjkl kabg djfa;gzjdffdsfgadshlifaghoisgshg ofdhl djsaghdfhgldfjzhlgljhkdf;.gjkndflhdfnjlndaljnrdljgnfdg sdkzgjlfd;ng jfdglnzs;dgfzlnfbdkjfghsbklvkdnbvkjadlb/f jdfn;l zdgk;v rksdulngbjrslfhesutriWHOGWerkhewbNE;RDLVUBOdsEAS VTSLHFVSUTR UHOSG; DSGD;IJSbxIGS;NzzVFBS FDJLNGSB DL;SVdBL KBJLSARGN;IRS",
         "headerStyle": null,
-        "endCol": 0,
+        "endCol": 6,
         "displayType": "row",
         "startCol": 0,
         "index": 0
@@ -672,10 +672,50 @@
         "fieldType": "html",
         "data": "<p style=\"color: red;\">HELLO</p>",
         "headerStyle": null,
-        "endCol": 0,
+        "endCol": 3,
         "displayType": "row",
         "startCol": 0,
         "index": 1
+      },
+      {
+        "fieldId": "id4",
+        "fieldName": "Name 4",
+        "fieldType": "card",
+        "data": "### markdown text here\n- please look",
+        "headerStyle": null,
+        "endCol": 6,
+        "displayType": "card",
+        "startCol": 3,
+        "index": 1
+      },
+      {
+        "fieldId": "id3",
+        "fieldName": "Name 3",
+        "fieldType": "html",
+        "data": "<p style=\"color: green;text-align:center;\">CENTER</p>",
+        "headerStyle": null,
+        "endCol": 3,
+        "displayType": "row",
+        "startCol": 0,
+        "index": 2
+      },
+      {
+        "fieldId": "id5",
+        "fieldName": "Name 5",
+        "fieldType": "text",
+        "data": [{
+          "prop1": "this is prop 1",
+          "prop2": "this is prop 2"
+        }, {
+          "prop1": "this is prop 1",
+          "prop2": "this is prop 2",
+          "prop3": "this is prop 3"
+        }],
+        "headerStyle": null,
+        "endCol": 6,
+        "displayType": "card",
+        "startCol": 0,
+        "index": 3
       }
     ],
     "layout": {

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -364,7 +364,7 @@ describe('Report Container', () => {
 
     // Page break
     const markdown = reportContainer.find(SectionMarkdown);
-    expect(markdown).to.have.length(3);
+    expect(markdown).to.have.length(4);
     expect(markdown.at(0).text()).equal(sec8.data.text.replace(PAGE_BREAK_KEY, ''));
 
     // Items Section
@@ -380,17 +380,26 @@ describe('Report Container', () => {
     expect(itemValues).to.have.length(sec9.data.length);
     expect(itemValues.at(0).text()).to.equal(sec9.data[0].data);
     expect(itemValues.at(1).text()).to.equal('HELLO');
+    expect(itemValues.at(3).text()).to.equal('CENTER');
+
+    const markdownItem = itemValues.at(2).find(SectionMarkdown);
+    expect(markdownItem).to.have.length(1);
+    expect(markdownItem.at(0).props().text).to.equal(sec9.data[2].data);
+
+    const tableItem = itemValues.at(4).find(SectionTable);
+    expect(tableItem).to.have.length(1);
+    expect(tableItem.at(0).props().data).to.deep.equal(sec9.data[4].data);
 
     // Tables
     const sectionTable = reportContainer.find(SectionTable);
-    expect(sectionTable).to.have.length(1);
-    expect(sectionTable.at(0).props().columns).to.equal(sec10.layout.tableColumns);
-    expect(sectionTable.at(0).props().data).to.equal(sec10.data);
-    expect(sectionTable.at(0).props().classes).to.equal(sec10.layout.classes);
+    expect(sectionTable).to.have.length(2);
+    expect(sectionTable.at(1).props().columns).to.equal(sec10.layout.tableColumns);
+    expect(sectionTable.at(1).props().data).to.equal(sec10.data);
+    expect(sectionTable.at(1).props().classes).to.equal(sec10.layout.classes);
 
-    const tableEl = reportContainer.find('table');
-    const tableHeader = reportContainer.find('th');
-    expect(tableEl).to.have.length(2); // there is a table in duration display.
+    const tableEl = sectionTable.at(1).find('table');
+    const tableHeader = sectionTable.at(1).find('th');
+    expect(tableEl).to.have.length(1);
     expect(tableHeader).to.have.length(2);
     expect(tableHeader.at(0).text()).to.equal(sec10.layout.tableColumns[0]);
     expect(tableHeader.at(1).text()).to.equal(sec10.layout.tableColumns[1]);


### PR DESCRIPTION
- fixed overall sections and section items paddings
- fixed section items auto height sometimes does not apply
- fixed section item description position
![image](https://user-images.githubusercontent.com/18641362/84287941-38ac4e00-ab49-11ea-8a58-0bb1d5753fdb.png)

- added grouped list bold title
![image](https://user-images.githubusercontent.com/18641362/84288041-537ec280-ab49-11ea-90ae-5afe0a4d71ad.png)

- avoid stacking tables in section markdown too avoid miss calculation by the css media query
![image](https://user-images.githubusercontent.com/18641362/84288682-2aaafd00-ab4a-11ea-8249-773e5985e9fd.png)

- use better default margins of 0.5 inch for better standard side margin
![image](https://user-images.githubusercontent.com/18641362/84288709-339bce80-ab4a-11ea-97e8-f56eeaf12282.png)

- added test cases

