### PR TITLE
Protect line chart and table

### DIFF
--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -116,7 +116,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
 
   preparedLegend = values(lineTypes);
   preparedData = retData;
-  if (!isEmpty(legend)) {
+  if (!isEmpty(legend) && Object.keys(lineTypes).length > 1) {
     preparedLegend = legend.map((item) => {
       item.color = item.color || item.stroke || getGraphColorByName(item.name, existingColors);
       existingColors[item.color] = true;

--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -22,7 +22,7 @@ const SectionTable = ({ columns, readableHeaders, data, classes, style, title, t
   }
 
   if (!isArray(tableData) && isObjectLike(tableData)) {
-    tableData = tableData.data || tableData.iocs || tableData.messages;
+    tableData = tableData.data || tableData.iocs || tableData.messages || [];
   }
 
   let readyColumns = columns;


### PR DESCRIPTION
- add safe check for section table data
- ignore line chart legend when only one line. used to protect the line chart displaying incorrect values when legend is provided but not needed.

