### PR TITLE
Fix stack charts not considered stack based on data

### DIFF
--- a/src/components/Sections/SectionList.less
+++ b/src/components/Sections/SectionList.less
@@ -7,6 +7,7 @@
     margin: 5px 10px !important;
     .content {
       word-break: break-word;
+      padding: 0 2px;
     }
     .right-list-value {
       display: table-cell;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -16,7 +16,7 @@ import {
   SectionText,
   SectionHTML
 } from '../components/Sections';
-import { isNumber, isObjectLike, compact, isString, groupBy } from 'lodash';
+import { isNumber, isObjectLike, compact, isString, groupBy, get } from 'lodash';
 import React from 'react';
 
 function getDefaultEmptyNotification() {
@@ -156,7 +156,8 @@ export function getSectionComponent(section, maxWidth) {
           title={section.title}
           referenceLineX={section.layout.referenceLineX}
           referenceLineY={section.layout.referenceLineY}
-          stacked={section.query && section.query.groupBy && section.query.groupBy.length > 1}
+          stacked={get(section, 'query.groupBy.length', 0) > 1 ||
+          (Array.isArray(section.data) && section.data.some(group => get(group, 'groups.length') > 0))}
           fromDate={section.fromDate}
           toDate={section.toDate}
         />

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -45,13 +45,27 @@
         "name": "CCC",
         "relatedTo": 1,
         "value": [
-          1
+          5
         ],
         "groups": [
           {
             "name": "SubGroup1",
             "data": [
               1
+            ],
+            "groups": null
+          },
+          {
+            "name": "SubGroup3",
+            "data": [
+              1
+            ],
+            "groups": null
+          },
+          {
+            "name": "SubGroup4",
+            "data": [
+              3
             ],
             "groups": null
           }

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -24,6 +24,7 @@ import {
 import { BarChart, Bar, PieChart, Pie, LineChart, Line } from 'recharts';
 import { NONE_VALUE_DEFAULT_NAME, PAGE_BREAK_KEY } from '../../src/constants/Constants';
 import { DEFAULT_NONE_COLOR } from '../../src/utils/colors';
+import { unionBy } from 'lodash';
 
 function expectChartLegendFromChartElement(pieChart, dataArr) {
   const chartLegend = pieChart.find(ChartLegend);
@@ -350,7 +351,7 @@ describe('Report Container', () => {
     expect(barChart.at(0).props().height).to.equal(sec1.layout.dimensions.height);
     expect(barChart.at(0).props().data).to.deep.equal(sec1.data);
     const bars = barChart.at(0).find(Bar);
-    expect(bars).to.have.length(3);
+    expect(bars).to.have.length(sec1.data.reduce((prev, curr) => unionBy(prev, curr.groups, 'name'), []).length);
     expect(barChart.at(1).props().width).to.equal(sec4.layout.dimensions.width);
     expect(barChart.at(1).props().height).to.equal(sec4.layout.dimensions.height);
     expect(barChart.at(1).props().data).to.deep.equal(sec4.data);


### PR DESCRIPTION
fixed charts are not considered stack based on their data + check in test
add slight padding to lists sections

before:
![image](https://user-images.githubusercontent.com/18641362/106175094-627cb880-619e-11eb-9877-bc1a29ad59f2.png)

after:
![image](https://user-images.githubusercontent.com/18641362/106175159-77f1e280-619e-11eb-9ffc-053192ea0595.png)
