### PR TITLE
Add reference line support for line chart and horizontal bar chart

### DIFF
--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -2,7 +2,7 @@ import './SectionBarChart.less';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ChartLegend, { VALUE_FORMAT_TYPES } from './ChartLegend';
-import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend } from 'recharts';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ReferenceLine, Label } from 'recharts';
 import { isArray, orderBy, unionBy } from 'lodash';
 import { sortStrings } from '../../../utils/strings';
 import { getGraphColorByName } from '../../../utils/colors';
@@ -10,7 +10,7 @@ import { CHART_LAYOUT_TYPE, NONE_VALUE_DEFAULT_NAME } from '../../../constants/C
 import { AutoSizer } from 'react-virtualized';
 
 const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {},
-  legendStyle = null, sortBy, stacked }) => {
+  legendStyle = null, sortBy, stacked, referenceLineY }) => {
   const existingColors = {};
   const isColumnChart = chartProperties.layout === CHART_LAYOUT_TYPE.horizontal;
   let dataItems = {};
@@ -131,9 +131,22 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
               />
               }
               {chartProperties.layout === CHART_LAYOUT_TYPE.vertical && <XAxis type="number" allowDecimals={false} />}
-              {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <YAxis type="number" />}
+              {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal &&
+                <YAxis
+                  type="number"
+                  domain={
+                    [dataMin => Math.floor(Math.min(0, dataMin, referenceLineY.y || 0) * 1.33),
+                      dataMax => Math.ceil(Math.max(dataMax, referenceLineY.y || 0) * 1.33)]
+                  }
+                />
+              }
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal && <XAxis tick dataKey="name" type="category" />}
               <Tooltip />
+              {referenceLineY &&
+                <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke}>
+                  <Label value={referenceLineY.label} fill={referenceLineY.stroke} position="top" />
+                </ReferenceLine>
+              }
               {legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend &&
                 <Legend
                   content={<ChartLegend
@@ -178,6 +191,7 @@ SectionBarChart.propTypes = {
   legend: PropTypes.array,
   legendStyle: PropTypes.object,
   sortBy: PropTypes.object,
+  referenceLineY: PropTypes.object,
   stacked: PropTypes.bool
 };
 

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -135,8 +135,8 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
                 <YAxis
                   type="number"
                   domain={
-                    [dataMin => Math.floor(Math.min(0, dataMin, referenceLineY.y || 0) * 1.33),
-                      dataMax => Math.ceil(Math.max(dataMax, referenceLineY.y || 0) * 1.33)]
+                    [dataMin => Math.floor(Math.min(0, dataMin, (referenceLineY && referenceLineY.y) || 0) * 1.33),
+                      dataMax => Math.ceil(Math.max(dataMax, (referenceLineY && referenceLineY.y) || 0) * 1.33)]
                   }
                 />
               }

--- a/src/components/Sections/SectionChart/SectionChart.js
+++ b/src/components/Sections/SectionChart/SectionChart.js
@@ -28,6 +28,7 @@ const SectionChart = ({ type, data, style, dimensions, legend, chartProperties =
                     legendStyle={legendStyle}
                     sortBy={sortBy}
                     stacked={stacked}
+                    referenceLineY={referenceLineY}
                   />
                 );
                 break;

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -149,8 +149,8 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                 <YAxis
                   key="y"
                   domain={
-                    [dataMin => Math.floor(Math.min(0, dataMin, referenceLineY.y || 0) * 1.33),
-                      dataMax => Math.ceil(Math.max(dataMax, referenceLineY.y || 0) * 1.33)]
+                    [dataMin => Math.floor(Math.min(0, dataMin, (referenceLineY && referenceLineY.y) || 0) * 1.33),
+                      dataMax => Math.ceil(Math.max(dataMax, (referenceLineY && referenceLineY.y) || 0) * 1.33)]
                   }
                   label={chartProperties.axis && chartProperties.axis.y ? {
                     value: chartProperties.axis.y.label,

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -1,7 +1,7 @@
 import './SectionLineChart.less';
 import React from 'react';
 import PropTypes from 'prop-types';
-import { LineChart, Line, XAxis, YAxis, ReferenceLine, CartesianGrid, Tooltip, Legend } from 'recharts';
+import { LineChart, Label, Line, XAxis, YAxis, ReferenceLine, CartesianGrid, Tooltip, Legend } from 'recharts';
 import ChartLegend from './ChartLegend';
 import { cloneDeep, compact, isEmpty, values } from 'lodash';
 import { AutoSizer } from 'react-virtualized';
@@ -148,7 +148,10 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                 />,
                 <YAxis
                   key="y"
-                  domain={[0, dataMax => dataMax + Math.ceil(dataMax * 0.33)]}
+                  domain={
+                    [dataMin => Math.floor(Math.min(0, dataMin, referenceLineY.y || 0) * 1.33),
+                      dataMax => Math.ceil(Math.max(dataMax, referenceLineY.y || 0) * 1.33)]
+                  }
                   label={chartProperties.axis && chartProperties.axis.y ? {
                     value: chartProperties.axis.y.label,
                     angle: -90
@@ -166,7 +169,10 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
               {referenceLineX &&
                 <ReferenceLine x={referenceLineX.x} stroke={referenceLineX.stroke} label={referenceLineX.label} />}
               {referenceLineY &&
-                <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke} label={referenceLineY.label} />}
+                <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke}>
+                  <Label value={referenceLineY.label} fill={referenceLineY.stroke} position="top" />
+                </ReferenceLine>
+              }
               {legendStyle && !legendStyle.hideLegend &&
                 <Legend
                   content={<ChartLegend

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -488,6 +488,11 @@
       }
     ],
     "layout": {
+      "referenceLineY": {
+        "y": 6,
+        "label": "Average",
+        "stroke": "rgb(64, 65, 66)"
+      },
       "chartProperties": {
         "format": "DD MMM Y",
         "isDatesChart": true,
@@ -624,6 +629,11 @@
       }
     ],
     "layout": {
+      "referenceLineY": {
+        "y": 6,
+        "label": "Average",
+        "stroke": "rgb(64, 65, 66)"
+      },
       "chartProperties": {
         "barSize": 35,
         "layout": "horizontal"

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -355,6 +355,13 @@ describe('Report Container', () => {
     expect(barChart.at(1).props().width).to.equal(sec4.layout.dimensions.width);
     expect(barChart.at(1).props().height).to.equal(sec4.layout.dimensions.height);
     expect(barChart.at(1).props().data).to.deep.equal(sec4.data);
+    let refLine = barChart.at(1).find('.recharts-reference-line-line');
+    expect(refLine.props().y).to.be.equal(sec4.layout.referenceLineY.y);
+    expect(refLine.props().stroke).to.be.equal(sec4.layout.referenceLineY.stroke);
+    let refLineLabel = barChart.at(1).find('.recharts-label');
+    expect(refLineLabel).to.have.length(2);
+    expect(refLineLabel.at(1).props().children[0].props.children).to.be.equal(sec4.layout.referenceLineY.label);
+
     expect(barChart.at(2).props().width).to.equal(sec5.layout.dimensions.width);
     expect(barChart.at(2).props().height).to.equal(sec5.layout.dimensions.height);
     expect(barChart.at(2).props().data).to.deep.equal(sec5.data);
@@ -368,6 +375,12 @@ describe('Report Container', () => {
 
     expect(lineChart.at(1).props().width).to.equal(sec7.layout.dimensions.width);
     expect(lineChart.at(1).props().height).to.equal(sec7.layout.dimensions.height);
+    refLine = lineChart.at(1).find('.recharts-reference-line-line');
+    expect(refLine.props().y).to.be.equal(sec7.layout.referenceLineY.y);
+    expect(refLine.props().stroke).to.be.equal(sec7.layout.referenceLineY.stroke);
+    refLineLabel = lineChart.at(1).find('.recharts-label');
+    expect(refLineLabel).to.have.length(2);
+    expect(refLineLabel.at(1).props().children[0].props.children).to.be.equal(sec7.layout.referenceLineY.label);
     lines = lineChart.at(1).find(Line);
     expect(lines).to.have.length(2);
     expect(lines.at(0).props().stroke).to.equal(sec7.data[1].groups[0].color);


### PR DESCRIPTION
related <https://github.com/demisto/etc/issues/34536>

server PR | [link](https://github.com/demisto/server/pull/18218)
client PR | [link](https://github.com/demisto/web-client/pull/7710)

![image](https://user-images.githubusercontent.com/47333909/112369934-74ce2b00-8ce5-11eb-97b3-2dfa8bdb5ead.png)


y axis domain handled accordingly 


