### PR TITLE
Fix number widget border

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -95,6 +95,11 @@ h1 {
         padding: 10px 12px 0;
       }
 
+      .section-number {
+        border: 1px solid #DADBDB;
+        padding: 10px 12px;
+      }
+
       .section-table {
         border: 1px solid #DADBDB;
         padding: 10px 12px;

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -95,12 +95,7 @@ h1 {
         padding: 10px 12px 0;
       }
 
-      .section-number {
-        border: 1px solid #DADBDB;
-        padding: 10px 12px;
-      }
-
-      .section-table {
+      .section-number, .section-table {
         border: 1px solid #DADBDB;
         padding: 10px 12px;
       }

--- a/src/components/Sections/SectionNumber.less
+++ b/src/components/Sections/SectionNumber.less
@@ -20,6 +20,7 @@
       display: inline-block;
       margin-left: 5px;
       .trend-box {
+        margin-top: 10px;
         border-radius: 100px;
         padding: 3px 10px 3px 5px;
         background-color: #FFF;


### PR DESCRIPTION
add border to widget number as the height and width already fixed

Fixes https://github.com/demisto/etc/issues/34232

<img width="433" alt="Screen Shot 2021-04-19 at 15 22 28" src="https://user-images.githubusercontent.com/63541536/115235683-2022a200-a123-11eb-843b-12446d608fbd.png">
