### PR TITLE
hide overflow for duration section

### DIFF
--- a/src/components/Sections/SectionDuration.less
+++ b/src/components/Sections/SectionDuration.less
@@ -4,6 +4,7 @@
   margin: auto;
   width: 100%;
   height: 100%;
+  overflow-x: hidden;
   .section-title {
     font-size: 18px;
     margin-bottom: 10px;


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
Fixes https://github.com/demisto/etc/issues/34218

## Related PRs
branch | PR
------ | ------
web PR | [link](<https://github.com/demisto/web-client/pull/7991>)

## Description
Hide horizontal overflow for duration section

## Screenshots
<img width="1338" alt="Screen Shot 2021-04-27 at 10 56 22" src="https://user-images.githubusercontent.com/76961496/116206930-fa5f5380-a747-11eb-9022-7e723f858128.png">
<img width="1338" alt="Screen Shot 2021-04-27 at 10 56 07" src="https://user-images.githubusercontent.com/76961496/116206937-fcc1ad80-a747-11eb-8ade-2d14aa321665.png">