### PR TITLE
fix line/bar chart axis name overflow

### DIFF
--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -219,7 +219,7 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
               </YAxis>}
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal &&
               <XAxis tick dataKey="name" type="category" {...xAxisProps}>
-                {chartProperties.axis && chartProperties.axis.x &&chartProperties.axis.x.label &&
+                {chartProperties.axis && chartProperties.axis.x && chartProperties.axis.x.label &&
                 <Label
                   value={rightEllipsis(chartProperties.axis.x.label, Math.floor(finalWidth / 12))}
                   offset={3}

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 import ChartLegend, { VALUE_FORMAT_TYPES } from './ChartLegend';
 import { Bar, BarChart, Label, LabelList, Legend, ReferenceLine, Tooltip, XAxis, YAxis } from 'recharts';
 import { isArray, orderBy } from 'lodash';
-import { createMiddleEllipsisFormatter, formatNumberValue, getTextWidth } from '../../../utils/strings';
+import { createMiddleEllipsisFormatter, formatNumberValue, getTextWidth, rightEllipsis } from '../../../utils/strings';
 import { sortByField } from '../../../utils/sort';
 import { getGraphColorByName } from '../../../utils/colors';
 import {
@@ -210,16 +210,21 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
               >
                 {chartProperties.axis && chartProperties.axis.y &&
                 <Label
-                  value={chartProperties.axis.y.label}
+                  value={rightEllipsis(chartProperties.axis.y.label, Math.floor(finalHeight / 12))}
                   angle={-90}
-                  offset={16}
+                  offset={6}
+                  style={{ textAnchor: 'middle' }}
                   position="insideLeft"
                 />}
               </YAxis>}
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal &&
               <XAxis tick dataKey="name" type="category" {...xAxisProps}>
                 {chartProperties.axis && chartProperties.axis.x &&
-                <Label value={chartProperties.axis.x.label} offset={3} position="insideBottom" />}
+                <Label
+                  value={rightEllipsis(chartProperties.axis.x.label, Math.floor(finalWidth / 12))}
+                  offset={3}
+                  position="insideBottom"
+                />}
               </XAxis>}
               <Tooltip />
               {referenceLineY &&

--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -208,7 +208,7 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
                     dataMax => Math.ceil(Math.max(dataMax, (referenceLineY && referenceLineY.y) || 0) * 1.33)]
                 }
               >
-                {chartProperties.axis && chartProperties.axis.y &&
+                {chartProperties.axis && chartProperties.axis.y && chartProperties.axis.y.label &&
                 <Label
                   value={rightEllipsis(chartProperties.axis.y.label, Math.floor(finalHeight / 12))}
                   angle={-90}
@@ -219,7 +219,7 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
               </YAxis>}
               {chartProperties.layout === CHART_LAYOUT_TYPE.horizontal &&
               <XAxis tick dataKey="name" type="category" {...xAxisProps}>
-                {chartProperties.axis && chartProperties.axis.x &&
+                {chartProperties.axis && chartProperties.axis.x &&chartProperties.axis.x.label &&
                 <Label
                   value={rightEllipsis(chartProperties.axis.x.label, Math.floor(finalWidth / 12))}
                   offset={3}

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -16,7 +16,7 @@ import {
 } from '../../../constants/Constants';
 import { compareFields } from '../../../utils/sort';
 import { getGraphColorByName } from '../../../utils/colors';
-import { getTextWidth } from '../../../utils/strings';
+import { getTextWidth, rightEllipsis } from '../../../utils/strings';
 import { calculateAngledTickInterval } from '../../../utils/ticks';
 
 const SINGLE_LINE_CHART_NAME = 'sum';
@@ -184,23 +184,29 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                   key="x"
                   interval="preserveStartEnd"
                   {...xAxisProps}
-                  label={chartProperties.axis && chartProperties.axis.x ? {
-                    value: chartProperties.axis.x.label,
-                    position: 'insideBottom',
-                    offset: 0
-                  } : undefined}
-                />,
+                >
+                  {chartProperties.axis && chartProperties.axis.x &&
+                  <Label
+                    value={rightEllipsis(chartProperties.axis.x.label, Math.floor(finalWidth / 12))}
+                    offset={-5}
+                    position="insideBottom"
+                  />}
+                </XAxis>,
                 <YAxis
                   key="y"
                   domain={
                     [dataMin => Math.floor(Math.min(0, dataMin, (referenceLineY && referenceLineY.y) || 0) * 1.33),
                       dataMax => Math.ceil(Math.max(dataMax, (referenceLineY && referenceLineY.y) || 0) * 1.33)]
                   }
-                  label={chartProperties.axis && chartProperties.axis.y ? {
-                    value: chartProperties.axis.y.label,
-                    angle: -90
-                  } : undefined}
-                />
+                >
+                  {chartProperties.axis && chartProperties.axis.y && <Label
+                    value={rightEllipsis(chartProperties.axis.y.label, Math.floor(finalHeight / 12))}
+                    angle={270}
+                    offset={6}
+                    style={{ textAnchor: 'middle' }}
+                    position="left"
+                  />}
+                </YAxis>
               ]}
               {(referenceLineY || chartProperties.layout === 'horizontal') && <YAxis dataKey="name" />}
               <CartesianGrid

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -185,7 +185,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                   interval="preserveStartEnd"
                   {...xAxisProps}
                 >
-                  {chartProperties.axis && chartProperties.axis.x &&
+                  {chartProperties.axis && chartProperties.axis.x && chartProperties.axis.x.label &&
                   <Label
                     value={rightEllipsis(chartProperties.axis.x.label, Math.floor(finalWidth / 12))}
                     offset={-5}
@@ -199,7 +199,8 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
                       dataMax => Math.ceil(Math.max(dataMax, (referenceLineY && referenceLineY.y) || 0) * 1.33)]
                   }
                 >
-                  {chartProperties.axis && chartProperties.axis.y && <Label
+                  {chartProperties.axis && chartProperties.axis.y && chartProperties.axis.y.label &&
+                  <Label
                     value={rightEllipsis(chartProperties.axis.y.label, Math.floor(finalHeight / 12))}
                     angle={270}
                     offset={6}

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -109,6 +109,10 @@ export function middleEllipsis(value, ellipsisThreshold, startLength, endLength)
   return newValue;
 }
 
+export function rightEllipsis(text, threshold) {
+  return middleEllipsis(text, threshold, threshold);
+}
+
 export function createMiddleEllipsisFormatter(maxLen) {
   const partsLen = maxLen - 3;
   const partLeft = Math.ceil(partsLen / 2);


### PR DESCRIPTION
Fixes <https://github.com/demisto/etc/issues/36649>

Web Client PR: https://github.com/demisto/web-client/pull/8225

fix line chart axis name overflow
fix bar chart axis name overflow
add ellipsis to axis names

how it looks on report now:
![image](https://user-images.githubusercontent.com/47333909/118976197-6dda3680-b97d-11eb-87ee-e122fcf0664c.png)

how it looks on the report builder:
![image](https://user-images.githubusercontent.com/47333909/118976404-a24df280-b97d-11eb-8d47-5d0105330584.png)
