### PR TITLE
fix reference line title overlap single bar value

### DIFF
--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -298,7 +298,11 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
                   )}
               {referenceLineY &&
               <ReferenceLine y={referenceLineY.y} stroke={referenceLineY.stroke}>
-                <Label value={referenceLineY.label} fill={referenceLineY.stroke} position="top" />
+                <Label
+                  value={referenceLineY.label}
+                  fill={referenceLineY.stroke}
+                  position={chartProperties.showValues && dataItems.length === 1 ? 'insideBottomRight' : 'top'}
+                />
               </ReferenceLine>
               }
             </BarChart>);


### PR DESCRIPTION
Align sane report to UI logic.
when we have single bar (it is aligned to the middle of the chart) its value will overlap with the reference line title.

solution in the UI is to move the reference line title to the right side in this flow.

How it looks in report
![image](https://user-images.githubusercontent.com/47333909/119825788-02094800-bf00-11eb-8002-eaa4b21c0333.png)

How it looks in UI
![image](https://user-images.githubusercontent.com/47333909/119825833-0d5c7380-bf00-11eb-8576-6d29b04b4069.png)

fixes https://github.com/demisto/etc/issues/37444