### PR TITLE
sane - disable tick word wrap

### DIFF
--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -181,7 +181,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
       <AutoSizer>
         {({ width, height }) => {
           const finalWidth = width || dimensions.width;
-          const xAxisProps = createXAxisProps(data, 'name', finalWidth * 0.6);
+          const xAxisProps = createXAxisProps(preparedData, 'name', finalWidth * 0.6);
           const finalHeight = isFull ? dimensions.height : height || dimensions.height;
 
           return (

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -35,6 +35,9 @@ const createXAxisProps = (data, dataKey, width) => {
     props.textAnchor = 'end';
     props.angle = WIDGET_DEFAULT_CONF.tickAngle;
     props.height = getTextWidth(ticks[0], WIDGET_DEFAULT_CONF.font) + 10;
+    props.tick = {
+      width: 0
+    };
     props.dx = -5;
     props.dy = 0;
   }


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
Fixes https://github.com/demisto/etc/issues/37378

## Related PRs
branch | PR
------ | ------
Web PR | [link](<https://github.com/demisto/web-client/pull/8284>)

## Description
Disable tick auto word wrap for line chart x-axis (recharts internals)

## Screenshots
![image](https://user-images.githubusercontent.com/76961496/120158403-c2db3f80-c1fc-11eb-826a-dd01cffbdeee.png)
