### PR TITLE
fix line chart - remove extra date added when no to date

### DIFF
--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -56,7 +56,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
     return formatNumberValue(v, valuesFormat);
   };
 
-  const finalToDate = toDate || moment().subtract(1, 'days').utc();
+  const finalToDate = toDate || moment().utc();
   const timeFrame = chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;
   const lineTypes = {};
   let from = fromDate && moment(fromDate).utc();
@@ -134,29 +134,30 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
 
   const currentDate = moment(from);
   for (let i = 0; i <= frames; i++) {
-    const formattedDate = timeFrame !== SUPPORTED_TIME_FRAMES.none ?
-      currentDate.format(timeFormat) : preparedData[i].name;
-    const mainGroup = preparedData.filter(item =>
-      formattedDate === item.name);
-    const group = mainGroup && mainGroup.length > 0 && mainGroup[0];
-    if (!group) {
-      const dataObj = {
-        name: formattedDate
-      };
-      Object.keys(lineTypes).forEach((groupName) => {
-        dataObj[groupName] = 0;
-      });
-      retData.push(dataObj);
-    } else {
+    if (currentDate <= finalToDate) {
+      const formattedDate = timeFrame !== SUPPORTED_TIME_FRAMES.none ?
+        currentDate.format(timeFormat) : preparedData[i].name;
+      const mainGroup = preparedData.filter(item =>
+        formattedDate === item.name);
+      const group = mainGroup && mainGroup.length > 0 && mainGroup[0];
+      if (!group) {
+        const dataObj = {
+          name: formattedDate
+        };
+        Object.keys(lineTypes).forEach((groupName) => {
+          dataObj[groupName] = 0;
+        });
+        retData.push(dataObj);
+      } else {
       // complete missing subgroups for the graph to show complete lines.
-      Object.keys(lineTypes).forEach((groupName) => {
-        if (!(groupName in group)) {
-          group[groupName] = 0;
-        }
-      });
-      retData.push(group);
+        Object.keys(lineTypes).forEach((groupName) => {
+          if (!(groupName in group)) {
+            group[groupName] = 0;
+          }
+        });
+        retData.push(group);
+      }
     }
-
     currentDate.add(1, timeFrame);
   }
   preparedLegend = values(lineTypes);

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -56,7 +56,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
     return formatNumberValue(v, valuesFormat);
   };
 
-  const finalToDate = toDate || moment().utc();
+  const finalToDate = toDate || moment().subtract(1, 'days').utc();
   const timeFrame = chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;
   const lineTypes = {};
   let from = fromDate && moment(fromDate).utc();
@@ -130,7 +130,7 @@ const SectionLineChart = ({ data, style, dimensions, legend, chartProperties = {
 
   const retData = [];
   const frames = timeFrame !== SUPPORTED_TIME_FRAMES.none ?
-    Math.ceil(finalToDate.diff(from, timeFrame, true)) - 1 : preparedData.length - 1;
+    Math.ceil(finalToDate.diff(from, timeFrame, true)) : preparedData.length - 1;
 
   const currentDate = moment(from);
   for (let i = 0; i <= frames; i++) {

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -399,7 +399,7 @@ describe('Report Container', () => {
 
     expect(lineChart.at(1).props().width).to.equal(sec7.layout.dimensions.width);
     expect(lineChart.at(1).props().height).to.equal(sec7.layout.dimensions.height);
-    expect(lineChart.at(1).props().data.length).to.equal(2);
+    expect(lineChart.at(1).props().data.length).to.equal(3);
     refLine = lineChart.at(1).find('.recharts-reference-line-line');
     expect(refLine.props().y).to.be.equal(sec7.layout.referenceLineY.y);
     expect(refLine.props().stroke).to.be.equal(sec7.layout.referenceLineY.stroke);

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -395,7 +395,7 @@ describe('Report Container', () => {
     expect(lineChart.at(0).find('.xAxis').at(0).text()).to.contain(sec6.layout.chartProperties.axis.x.label);
     expect(lineChart.at(0).find('.yAxis').at(0).text()).to.contain(sec6.layout.chartProperties.axis.y.label);
     expect(lineChart.at(0).props().data[0].name).to.equal('11 Dec 2017');
-    expect(lineChart.at(0).props().data.length).to.equal(1268);
+    expect(lineChart.at(0).props().data.length).to.equal(1269);
 
     expect(lineChart.at(1).props().width).to.equal(sec7.layout.dimensions.width);
     expect(lineChart.at(1).props().height).to.equal(sec7.layout.dimensions.height);


### PR DESCRIPTION
related <https://github.com/demisto/sane-reports/pull/164>
fixes <https://github.com/demisto/etc/issues/37580>
fixes a bug(missing last date) when passing to date 


before 
![image](https://user-images.githubusercontent.com/61918543/120287789-40b84d00-c2c8-11eb-83d1-bb0262bb52dd.png)

after
![image](https://user-images.githubusercontent.com/61918543/120287937-6180a280-c2c8-11eb-92eb-86ca0ecbf970.png)
