### PR TITLE
show time range message on widgets 

### DIFF
--- a/src/components/Sections/SectionChart/SectionChart.js
+++ b/src/components/Sections/SectionChart/SectionChart.js
@@ -11,10 +11,17 @@ import { isEmpty } from 'lodash';
 
 const SectionChart = ({ type, data, groupBy, style, dimensions, legend, chartProperties = {}, legendStyle = {},
   sortBy, referenceLineX, referenceLineY, title, stacked, fromDate, toDate, titleStyle, reflectDimensions,
-  emptyString }) => {
+  emptyString, forceRangeMessage }) => {
   return (
     <div className="section-chart" style={style}>
-      {title && <div className="section-title" style={titleStyle}>{title}</div>}
+      <div className="section-title-wrapper">
+        {title && <div className="section-title" style={titleStyle}>{title}</div>}
+        {forceRangeMessage && (
+        <div className="forced-time-range" title={forceRangeMessage}>
+          {forceRangeMessage}
+        </div>
+        )}
+      </div>
       {!isEmpty(data) && data.length > 0 ?
             (() => {
               let chartToRender;
@@ -101,7 +108,8 @@ SectionChart.propTypes = {
   fromDate: PropTypes.string,
   toDate: PropTypes.string,
   emptyString: PropTypes.string,
-  reflectDimensions: PropTypes.bool
+  reflectDimensions: PropTypes.bool,
+  forceRangeMessage: PropTypes.string
 };
 
 export default SectionChart;

--- a/src/components/Sections/SectionChart/SectionChart.js
+++ b/src/components/Sections/SectionChart/SectionChart.js
@@ -8,20 +8,14 @@ import WidgetEmptyState from '../WidgetEmptyState';
 import { CHART_TYPES } from '../../../constants/Constants';
 import moment from 'moment';
 import { isEmpty } from 'lodash';
+import SectionTitle from '../SectionTitle';
 
 const SectionChart = ({ type, data, groupBy, style, dimensions, legend, chartProperties = {}, legendStyle = {},
   sortBy, referenceLineX, referenceLineY, title, stacked, fromDate, toDate, titleStyle, reflectDimensions,
   emptyString, forceRangeMessage }) => {
   return (
     <div className="section-chart" style={style}>
-      <div className="section-title-wrapper">
-        {title && <div className="section-title" style={titleStyle}>{title}</div>}
-        {forceRangeMessage && (
-        <div className="forced-time-range" title={forceRangeMessage}>
-          {forceRangeMessage}
-        </div>
-        )}
-      </div>
+      <SectionTitle title={title} titleStyle={titleStyle} subTitle={forceRangeMessage} />
       {!isEmpty(data) && data.length > 0 ?
             (() => {
               let chartToRender;

--- a/src/components/Sections/SectionChart/SectionChart.less
+++ b/src/components/Sections/SectionChart/SectionChart.less
@@ -5,19 +5,4 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-
-  .section-title-wrapper{
-    display: flex;
-
-    .section-title {
-      font-size: 18px;
-    }
-    .forced-time-range{
-      margin-left: 4px;
-      font-style: italic;
-      color: #ff9000;
-      font-size: 14px;
-      font-weight: 700;
-    }
-  }
 }

--- a/src/components/Sections/SectionChart/SectionChart.less
+++ b/src/components/Sections/SectionChart/SectionChart.less
@@ -5,7 +5,19 @@
   width: 100%;
   display: flex;
   flex-direction: column;
-  .section-title {
-    font-size: 18px;
+
+  .section-title-wrapper{
+    display: flex;
+
+    .section-title {
+      font-size: 18px;
+    }
+    .forced-time-range{
+      margin-left: 4px;
+      font-style: italic;
+      color: #ff9000;
+      font-size: 14px;
+      font-weight: 700;
+    }
   }
 }

--- a/src/components/Sections/SectionDuration.js
+++ b/src/components/Sections/SectionDuration.js
@@ -6,6 +6,7 @@ import {
   DURATION_FORMAT,
   WIDGET_FORMAT_PARTS
 } from '../../constants/Constants';
+import SectionTitle from './SectionTitle';
 
 function formatNumber(num) {
   return ('0' + num).slice(-2);
@@ -51,7 +52,7 @@ const getLabels = (chartProperties) => {
   };
 };
 
-const SectionDuration = ({ data, style, chartProperties, title, titleStyle }) => {
+const SectionDuration = ({ data, style, chartProperties, title, titleStyle, forceRangeMessage }) => {
   let result = data.length > 0 && isArray(data[0].data) && data[0].data.length > 0 ? data[0].data[0] : 0;
   const format = chartProperties && chartProperties.format;
   const labels = getLabels(chartProperties);
@@ -90,7 +91,7 @@ const SectionDuration = ({ data, style, chartProperties, title, titleStyle }) =>
 
   return (
     <div className="section-duration" style={style}>
-      {title && <div className="section-title" style={titleStyle}>{title}</div>}
+      <SectionTitle title={title} titleStyle={titleStyle} subTitle={forceRangeMessage} />
       <div className="duration-widget-container">
         <div className="ui center aligned middle aligned grid duration-widget">
           <div className="four wide column" style={{ padding: 0 }}>
@@ -118,7 +119,8 @@ SectionDuration.propTypes = {
   style: PropTypes.object,
   title: PropTypes.string,
   chartProperties: PropTypes.object,
-  titleStyle: PropTypes.object
+  titleStyle: PropTypes.object,
+  forceRangeMessage: PropTypes.string
 };
 
 export default SectionDuration;

--- a/src/components/Sections/SectionGroupedList.js
+++ b/src/components/Sections/SectionGroupedList.js
@@ -2,13 +2,15 @@ import './SectionGroupedList.less';
 import React from 'react';
 import PropTypes from 'prop-types';
 import SectionList from './SectionList';
+import SectionTitle from './SectionTitle';
 
-const SectionGroupedList = ({ columns, data, classes, style, title, titleStyle, groupClass, emptyString }) => {
+const SectionGroupedList = ({ columns, data, classes, style, title, titleStyle, groupClass,
+  emptyString, forceRangeMessage }) => {
   const groupedData = data || {};
   const mainClass = `section-grouped-list ${classes}`;
   return (
     <div className={mainClass} style={style}>
-      {title && <div className="section-title" style={titleStyle}>{title}</div>}
+      <SectionTitle title={title} titleStyle={titleStyle} subTitle={forceRangeMessage} />
       {Object.keys(groupedData).map((groupName) => {
         return (
           <div className="grouped-item item h3" key={groupName}>
@@ -34,7 +36,8 @@ SectionGroupedList.propTypes = {
   title: PropTypes.string,
   groupClass: PropTypes.object,
   titleStyle: PropTypes.object,
-  emptyString: PropTypes.string
+  emptyString: PropTypes.string,
+  forceRangeMessage: PropTypes.string
 };
 
 export default SectionGroupedList;

--- a/src/components/Sections/SectionList.js
+++ b/src/components/Sections/SectionList.js
@@ -6,6 +6,7 @@ import { isString, isEmpty, isObject } from 'lodash';
 import moment from 'moment';
 import { TABLE_CELL_TYPE } from '../../constants/Constants';
 import WidgetEmptyState from './WidgetEmptyState';
+import SectionTitle from './SectionTitle';
 
 function getFieldComponentIfNeeded(dataValue) {
   return isObject(dataValue) && dataValue.type === TABLE_CELL_TYPE.image ? (<img
@@ -45,7 +46,7 @@ function styleByFieldName(fieldName, currentData) {
   }
 }
 
-const SectionList = ({ columns, data, classes, style, title, titleStyle, emptyString }) => {
+const SectionList = ({ columns, data, classes, style, title, titleStyle, emptyString, forceRangeMessage }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -58,7 +59,7 @@ const SectionList = ({ columns, data, classes, style, title, titleStyle, emptySt
   const mainClass = `section-list ${classes || ''}`;
   return (
     <div className={mainClass} style={style}>
-      {title && <div className="section-title" style={titleStyle}>{title}</div>}
+      <SectionTitle title={title} titleStyle={titleStyle} subTitle={forceRangeMessage} />
       <div className="list-data-container">
         {tableData.length > 0 ? tableData.map((item) => {
           let leftName = 'name';
@@ -111,7 +112,8 @@ SectionList.propTypes = {
   style: PropTypes.object,
   title: PropTypes.string,
   titleStyle: PropTypes.object,
-  emptyString: PropTypes.string
+  emptyString: PropTypes.string,
+  forceRangeMessage: PropTypes.string
 };
 
 export default SectionList;

--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -20,6 +20,7 @@ import mark from 'markdown-it-mark';
 import footnote from 'markdown-it-footnote';
 import deflist from 'markdown-it-deflist';
 import ins from 'markdown-it-ins';
+import SectionTitle from './SectionTitle';
 // end of import plugin
 
 const IGNORE_KEYS = [PAGE_BREAK_KEY];
@@ -33,7 +34,8 @@ export default class SectionMarkdown extends Component {
     tableClasses: PropTypes.oneOfType([
       PropTypes.object,
       PropTypes.string
-    ])
+    ]),
+    forceRangeMessage: PropTypes.string
   };
 
   static createBtn(props, children) {
@@ -162,7 +164,7 @@ export default class SectionMarkdown extends Component {
   }
 
   render() {
-    const { text, style, tableClasses, doNotShowEmoji, setRef, customClass } = this.props;
+    const { text, style, tableClasses, doNotShowEmoji, setRef, customClass, forceRangeMessage } = this.props;
     let finalText = text;
     IGNORE_KEYS.forEach((s) => {
       finalText = (finalText || '').replace(s, '');
@@ -202,6 +204,7 @@ export default class SectionMarkdown extends Component {
 
     return (
       <div className={`section-markdown ${customClass || ''}`} ref={setRef} style={style}>
+        <SectionTitle subTitle={forceRangeMessage} />
         {res}
       </div>
     );

--- a/src/components/Sections/SectionNumber.js
+++ b/src/components/Sections/SectionNumber.js
@@ -9,7 +9,7 @@ import { capitalizeFirstLetter, formatNumberValue } from '../../utils/strings';
 const TREND_NUMBER_LIMIT = 999;
 const SectionNumber = ({
   data, layout, style, sign, signAlignment, title, titleStyle, valuesFormat = WIDGET_VALUES_FORMAT.abbreviated,
-                         subTitle, numberStyle = {}
+  subTitle, numberStyle = {}
 }) => {
   const isTrend = !!data.prevSum || data.prevSum === 0;
   let percentage = 0;

--- a/src/components/Sections/SectionNumber.js
+++ b/src/components/Sections/SectionNumber.js
@@ -4,11 +4,12 @@ import PropTypes from 'prop-types';
 import values from 'lodash/values';
 import classNames from 'classnames';
 import { CHART_LAYOUT_TYPE, WIDGET_VALUES_FORMAT } from '../../constants/Constants';
-import { formatNumberValue } from '../../utils/strings';
+import { capitalizeFirstLetter, formatNumberValue } from '../../utils/strings';
 
 const TREND_NUMBER_LIMIT = 999;
 const SectionNumber = ({
-  data, layout, style, sign, signAlignment, title, titleStyle, valuesFormat = WIDGET_VALUES_FORMAT.abbreviated
+  data, layout, style, sign, signAlignment, title, titleStyle, valuesFormat = WIDGET_VALUES_FORMAT.abbreviated,
+  subTitle
 }) => {
   const isTrend = !!data.prevSum || data.prevSum === 0;
   let percentage = 0;
@@ -35,6 +36,9 @@ const SectionNumber = ({
 
   const color = style && style.backgroundColor ? '#FFF' : undefined;
   const titleColor = (titleStyle && titleStyle.color) ? titleStyle.color : color;
+  const subTitleClass = classNames('demisto-number-sub-title', {
+    'color-warning': !color
+  });
   let trendContainer = '';
   if (isTrend) {
     const boxClass = classNames('trend-box', {
@@ -68,7 +72,12 @@ const SectionNumber = ({
         trendContainer
         }
         <div className="trend-message" style={{ ...titleStyle, color: titleColor }}>
-          {title}
+          {capitalizeFirstLetter(title)}
+          {subTitle && (
+          <div className={subTitleClass} style={{ color: color || '#ff9000' }} title={subTitle}>
+            {subTitle}
+          </div>
+          )}
         </div>
         {layout === CHART_LAYOUT_TYPE.vertical && isTrend &&
         trendContainer
@@ -85,7 +94,8 @@ SectionNumber.propTypes = {
   layout: PropTypes.oneOf(values(CHART_LAYOUT_TYPE)),
   sign: PropTypes.string,
   signAlignment: PropTypes.string,
-  valuesFormat: PropTypes.oneOf(values(WIDGET_VALUES_FORMAT))
+  valuesFormat: PropTypes.oneOf(values(WIDGET_VALUES_FORMAT)),
+  subTitle: PropTypes.string
 };
 
 export default SectionNumber;

--- a/src/components/Sections/SectionNumber.less
+++ b/src/components/Sections/SectionNumber.less
@@ -52,7 +52,17 @@
       text-align: center;
       margin-top: 10px;
       padding: 0 7px;
-      font-size: 18px;
+      font-size: 1.2em;
+      text-shadow: 0 2px 3px rgba(0, 0, 0, 0.1);
+      font-weight: 700;
+
+      .color-warning{
+        text-shadow: none;
+      }
+      .demisto-number-sub-title{
+        font-size: 14px;
+        padding-top: 3px;
+      }
     }
 
     .icon {

--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -4,10 +4,11 @@ import PropTypes from 'prop-types';
 import { TABLE_CELL_TYPE, DEFAULT_MAX_LENGTH } from '../../constants/Constants';
 import { isEmpty, isString, isArray, truncate, isObjectLike, map } from 'lodash';
 import WidgetEmptyState from './WidgetEmptyState';
+import SectionTitle from './SectionTitle';
 
 
 const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, classes, style, title, titleStyle, emptyString,
-  maxColumns }) => {
+  maxColumns, forceRangeMessage }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -134,7 +135,7 @@ const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, classes
 
   return (
     <div className="section-table" style={style}>
-      {title && <div className="section-title" style={titleStyle}>{title}</div>}
+      <SectionTitle title={title} titleStyle={titleStyle} subTitle={forceRangeMessage} />
       {tableBody}
     </div>
   );
@@ -153,7 +154,8 @@ SectionTable.propTypes = {
   title: PropTypes.string,
   maxColumns: PropTypes.number,
   titleStyle: PropTypes.object,
-  emptyString: PropTypes.string
+  emptyString: PropTypes.string,
+  forceRangeMessage: PropTypes.string
 };
 
 export default SectionTable;

--- a/src/components/Sections/SectionTitle.js
+++ b/src/components/Sections/SectionTitle.js
@@ -1,0 +1,20 @@
+import './SectionTitle.less';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SectionTitle = ({ titleStyle, title, subTitle }) =>
+  <div className="section-title-wrapper">
+    {title && <div className="section-title" style={titleStyle}>{title}</div>}
+    {subTitle && (
+      <div className="section-sub-title" title={subTitle}>
+        {subTitle}
+      </div>
+      )}
+  </div>;
+SectionTitle.propTypes = {
+  title: PropTypes.string,
+  subTitle: PropTypes.string,
+  titleStyle: PropTypes.object
+};
+
+export default SectionTitle;

--- a/src/components/Sections/SectionTitle.less
+++ b/src/components/Sections/SectionTitle.less
@@ -1,0 +1,15 @@
+.section-title-wrapper {
+  display: flex;
+
+  .section-title {
+    font-size: 18px;
+  }
+
+  .section-sub-title{
+    margin-left: 4px;
+    font-style: italic;
+    color: #ff9000;
+    font-size: 14px;
+    font-weight: 700;
+  }
+}

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -89,6 +89,7 @@ export function getSectionComponent(section, maxWidth) {
           style={section.layout.style}
           titleStyle={section.titleStyle}
           title={section.title}
+          forceRangeMessage={section.layout.forceRangeMessage}
         />
       );
       break;
@@ -103,6 +104,7 @@ export function getSectionComponent(section, maxWidth) {
             titleStyle={section.titleStyle}
             title={section.title}
             emptyString={section.emptyNotification || getDefaultEmptyNotification()}
+            forceRangeMessage={section.layout.forceRangeMessage}
           />
         );
       } else {
@@ -115,6 +117,7 @@ export function getSectionComponent(section, maxWidth) {
             titleStyle={section.titleStyle}
             title={section.title}
             emptyString={section.emptyNotification || getDefaultEmptyNotification()}
+            forceRangeMessage={section.layout.forceRangeMessage}
           />
         );
       }
@@ -196,6 +199,7 @@ export function getSectionComponent(section, maxWidth) {
           title={section.title}
           maxColumns={section.layout.maxColumns || (maxWidth ? maxWidth / 100 : 0)}
           emptyString={section.emptyNotification || getDefaultEmptyNotification()}
+          forceRangeMessage={section.layout.forceRangeMessage}
         />
       );
       break;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -131,6 +131,7 @@ export function getSectionComponent(section, maxWidth) {
           tableClasses={section.layout.tableClasses}
           doNotShowEmoji={section.layout.doNotShowEmoji}
           customClass={isPageBreakSection(section) ? 'page-break-section' : ''}
+          forceRangeMessage={section.layout.forceRangeMessage}
         />
       );
       break;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -76,6 +76,7 @@ export function getSectionComponent(section, maxWidth) {
           text={section.data}
           style={section.layout.style}
           valuesFormat={section.layout.valuesFormat}
+          subTitle={section.layout.forceRangeMessage}
         />
       );
       break;
@@ -156,7 +157,6 @@ export function getSectionComponent(section, maxWidth) {
       const chartGroupField = groupByField && groupByField.length > 0 ? groupByField[groupByField.length - 1] : null;
       const processedData = processData(dataType, section.data, groupByField);
       const processedLegendData = processData(dataType, section.layout.legend, groupByField);
-
       sectionToRender = (
         <SectionChart
           data={processedData}
@@ -178,6 +178,7 @@ export function getSectionComponent(section, maxWidth) {
           reflectDimensions={section.layout.reflectDimensions}
           emptyString={section.emptyNotification || getDefaultEmptyNotification()}
           groupBy={chartGroupField}
+          forceRangeMessage={section.layout.forceRangeMessage}
         />
       );
       break;

--- a/src/utils/strings.js
+++ b/src/utils/strings.js
@@ -168,3 +168,7 @@ export function sentenceBreaker(str = '', maxLength, maxRows) {
   return words;
 }
 
+export function capitalizeFirstLetter(string) {
+  return string ? string.charAt(0).toUpperCase() + string.slice(1) : string;
+}
+

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -93,7 +93,8 @@
         "verticalAlign": "top"
       },
       "rowPos": 0,
-      "w": 2
+      "w": 2,
+      "forceRangeMessage": "Last 7 days"
     },
     "query": {
       "filter": {
@@ -129,7 +130,8 @@
         "backgroundColor": null
       },
       "w": 3,
-      "valuesFormat": "decimal"
+      "valuesFormat": "decimal",
+      "forceRangeMessage": "Last 7 days"
     },
     "query": {
       "filter": {
@@ -782,7 +784,8 @@
       "h": 1,
       "i": "50581960-333e-11e8-8c3c-57387b30abc2",
       "rowPos": 5,
-      "w": 12
+      "w": 12,
+      "forceRangeMessage": "30 May 2021 - 31 May 2021"
     },
     "title": "Duration"
   },
@@ -893,7 +896,8 @@
         "aaa",
         "bbb"
       ],
-      "w": 12
+      "w": 12,
+      "forceRangeMessage": "Last 7 days"
     },
     "title": "table"
   },

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -1145,5 +1145,17 @@
     },
     "fromDate": "2017-12-11T12:07:50+02:00",
     "title": "Test test"
+  },
+  {
+    "type": "markdown",
+    "data": { "text": "markdown with force range message" },
+    "layout": {
+      "rowPos": 11,
+      "columnPos": 0,
+      "h": 2,
+      "i": "ea707c90-9b20-11e9-90cd-2702611820x6",
+      "w": 12,
+      "forceRangeMessage": "Last 7 days"
+    }
   }
 ]

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -343,8 +343,8 @@ describe('Report Container', () => {
     expect(widgetProps.dimensions).to.equal(sec1.layout.dimensions);
 
     const sectionTitle = widget.find(SectionTitle);
-    expect(sectionTitle.find('.section-title').textContent).to.equal(sec1.layout.title);
-    expect(sectionTitle.find('.section-sub-title').textContent).to.equal(sec1.layout.forceRangeMessage);
+    expect(sectionTitle.find('.section-title').text()).to.equal(sec1.title);
+    expect(sectionTitle.find('.section-sub-title').text()).to.equal(sec1.layout.forceRangeMessage);
 
     expect(sectionChart.at(1).props().data).to.equal(sec3.data);
     expect(sectionChart.at(1).props().style).to.equal(sec3.layout.style);
@@ -448,7 +448,7 @@ describe('Report Container', () => {
     expect(widgetProps.data).to.equal(sec2.data);
     expect(widget.find('.trend-num-text').text()).to
       .equal(formatNumberValue(sec2.data.currSum, sec2.layout.valuesFormat));
-    expect(widget.find('.demisto-number-sub-title').textContent).to
+    expect(widget.find('.demisto-number-sub-title').text()).to
       .equal(sec2.layout.forceRangeMessage);
     expect(widgetProps.layout).to.equal(sec2.layout.layout);
     const trendBox = trendNumber.at(0).find('.trend-box.green');
@@ -460,7 +460,7 @@ describe('Report Container', () => {
     widget = duration.at(0);
     widgetProps = widget.props();
 
-    expect(widget.find('.section-sub-title').textContent).to
+    expect(widget.find('.section-sub-title').text()).to
       .equal(sec8.layout.forceRangeMessage);
 
     expect(widgetProps.title).to.equal(sec8.title);
@@ -508,7 +508,7 @@ describe('Report Container', () => {
     expect(widgetProps.data).to.equal(sec11.data);
     expect(widgetProps.classes).to.equal(sec11.layout.classes);
 
-    expect(widget.find('.section-sub-title').textContent).to
+    expect(widget.find('.section-sub-title').text()).to
       .equal(sec11.layout.forceRangeMessage);
 
     let tableEl = sectionTable.at(1).find('table');

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -26,6 +26,7 @@ import { DEFAULT_NONE_COLOR } from '../../src/utils/colors';
 import { cloneDeep, unionBy } from 'lodash';
 import SectionBarChart from '../../src/components/Sections/SectionChart/SectionBarChart';
 import { formatNumberValue } from '../../src/utils/strings';
+import SectionTitle from '../../src/components/Sections/SectionTitle';
 
 function expectChartLegendFromChartElement(chart, dataArr, showValue) {
   const chartLegend = chart.find(ChartLegend);
@@ -334,10 +335,16 @@ describe('Report Container', () => {
     // Charts
     const sectionChart = reportContainer.find(SectionChart);
     expect(sectionChart).to.have.length(8);
-    expect(sectionChart.at(0).props().data).to.equal(sec1.data);
-    expect(sectionChart.at(0).props().style).to.equal(sec1.layout.style);
-    expect(sectionChart.at(0).props().type).to.equal(sec1.layout.chartType);
-    expect(sectionChart.at(0).props().dimensions).to.equal(sec1.layout.dimensions);
+    let widget = sectionChart.at(0);
+    let widgetProps = widget.props();
+    expect(widgetProps.data).to.equal(sec1.data);
+    expect(widgetProps.style).to.equal(sec1.layout.style);
+    expect(widgetProps.type).to.equal(sec1.layout.chartType);
+    expect(widgetProps.dimensions).to.equal(sec1.layout.dimensions);
+
+    const sectionTitle = widget.find(SectionTitle);
+    expect(sectionTitle.find('.section-title').textContent).to.equal(sec1.layout.title);
+    expect(sectionTitle.find('.section-sub-title').textContent).to.equal(sec1.layout.forceRangeMessage);
 
     expect(sectionChart.at(1).props().data).to.equal(sec3.data);
     expect(sectionChart.at(1).props().style).to.equal(sec3.layout.style);
@@ -435,21 +442,31 @@ describe('Report Container', () => {
     // Trend
     const trendNumber = reportContainer.find(SectionNumber);
     expect(trendNumber).to.have.length(1);
-    expect(trendNumber.at(0).props().title).to.equal(sec2.title);
-    expect(trendNumber.at(0).props().data).to.equal(sec2.data);
-    expect(trendNumber.at(0).find('.trend-num-text').text()).to
+    widget = trendNumber.at(0);
+    widgetProps = widget.props();
+    expect(widgetProps.title).to.equal(sec2.title);
+    expect(widgetProps.data).to.equal(sec2.data);
+    expect(widget.find('.trend-num-text').text()).to
       .equal(formatNumberValue(sec2.data.currSum, sec2.layout.valuesFormat));
-    expect(trendNumber.at(0).props().layout).to.equal(sec2.layout.layout);
+    expect(widget.find('.demisto-number-sub-title').textContent).to
+      .equal(sec2.layout.forceRangeMessage);
+    expect(widgetProps.layout).to.equal(sec2.layout.layout);
     const trendBox = trendNumber.at(0).find('.trend-box.green');
     expect(trendBox).to.have.length(1);
 
     // Duration
     const duration = reportContainer.find(SectionDuration);
     expect(duration).to.have.length(1);
-    expect(duration.at(0).props().title).to.equal(sec8.title);
-    expect(duration.at(0).props().data).to.equal(sec8.data);
-    expect(duration.at(0).props().chartProperties).to.equal(sec8.layout.chartProperties);
-    const timeUnit = duration.at(0).find('.time-unit');
+    widget = duration.at(0);
+    widgetProps = widget.props();
+
+    expect(widget.find('.section-sub-title').textContent).to
+      .equal(sec8.layout.forceRangeMessage);
+
+    expect(widgetProps.title).to.equal(sec8.title);
+    expect(widgetProps.data).to.equal(sec8.data);
+    expect(widgetProps.chartProperties).to.equal(sec8.layout.chartProperties);
+    const timeUnit = widget.find('.time-unit');
     expect(timeUnit).to.have.length(3);
 
     // Page break
@@ -483,9 +500,16 @@ describe('Report Container', () => {
     // Tables
     const sectionTable = reportContainer.find(SectionTable);
     expect(sectionTable).to.have.length(3);
-    expect(sectionTable.at(1).props().columns).to.equal(sec11.layout.tableColumns);
-    expect(sectionTable.at(1).props().data).to.equal(sec11.data);
-    expect(sectionTable.at(1).props().classes).to.equal(sec11.layout.classes);
+
+    widget = sectionTable.at(1);
+    widgetProps = widget.props();
+
+    expect(widgetProps.columns).to.equal(sec11.layout.tableColumns);
+    expect(widgetProps.data).to.equal(sec11.data);
+    expect(widgetProps.classes).to.equal(sec11.layout.classes);
+
+    expect(widget.find('.section-sub-title').textContent).to
+      .equal(sec11.layout.forceRangeMessage);
 
     let tableEl = sectionTable.at(1).find('table');
     let tableHeader = sectionTable.at(1).find('th');

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -342,7 +342,7 @@ describe('Report Container', () => {
     expect(widgetProps.type).to.equal(sec1.layout.chartType);
     expect(widgetProps.dimensions).to.equal(sec1.layout.dimensions);
 
-    const sectionTitle = widget.find(SectionTitle);
+    let sectionTitle = widget.find(SectionTitle);
     expect(sectionTitle.find('.section-title').text()).to.equal(sec1.title);
     expect(sectionTitle.find('.section-sub-title').text()).to.equal(sec1.layout.forceRangeMessage);
 
@@ -471,8 +471,14 @@ describe('Report Container', () => {
 
     // Page break
     const markdown = reportContainer.find(SectionMarkdown);
-    expect(markdown).to.have.length(4);
+    expect(markdown).to.have.length(5);
     expect(markdown.at(0).text()).equal(sec9.data.text.replace(constants.PAGE_BREAK_KEY, ''));
+
+    // Markdown
+    const sec = testTemplate[14];
+    widget = markdown.at(4);
+    sectionTitle = widget.find(SectionTitle);
+    expect(sectionTitle.find('.section-sub-title').text()).to.equal(sec.layout.forceRangeMessage);
 
     // Items Section
     const itemsSection = reportContainer.find(ItemsSection);


### PR DESCRIPTION
Fixes <https://github.com/demisto/etc/issues/37804>
Related <https://github.com/demisto/etc/issues/34410#event-4857934791>

1) capitalize first letter - number widget
2) show forced time range message on charts
3) show forced time range on text \ number \ table \ list \ markdown \ duration'  widget

![image](https://user-images.githubusercontent.com/61918543/121049037-06671800-c7c0-11eb-8b13-f1addb7c1dbf.png)

![image](https://user-images.githubusercontent.com/61918543/121134669-584d8380-c83c-11eb-986c-52a2188ecba4.png)

markdown
![image](https://user-images.githubusercontent.com/61918543/121142842-1117c080-c845-11eb-916a-2a85dc771c90.png)

text
![image](https://user-images.githubusercontent.com/61918543/121142872-18d76500-c845-11eb-8f05-d0bc68ddf09f.png)

