### PR TITLE
Number widget optional styling support

### DIFF
--- a/src/components/Sections/SectionNumber.js
+++ b/src/components/Sections/SectionNumber.js
@@ -8,7 +8,8 @@ import { formatNumberValue } from '../../utils/strings';
 
 const TREND_NUMBER_LIMIT = 999;
 const SectionNumber = ({
-  data, layout, style, sign, signAlignment, title, titleStyle, valuesFormat = WIDGET_VALUES_FORMAT.abbreviated
+  data, layout, style, sign, signAlignment, title, titleStyle, valuesFormat = WIDGET_VALUES_FORMAT.abbreviated,
+  numberStyle = {}
 }) => {
   const isTrend = !!data.prevSum || data.prevSum === 0;
   let percentage = 0;
@@ -57,7 +58,7 @@ const SectionNumber = ({
       <div className="number-container">
         <div
           className="trend-num-text"
-          style={{ color }}
+          style={{ ...numberStyle, color }}
         >
           {signAlignment === 'left' && signElement}
           {formatNumberValue(curr,
@@ -82,6 +83,7 @@ SectionNumber.propTypes = {
   style: PropTypes.object,
   title: PropTypes.string,
   titleStyle: PropTypes.object,
+  numberStyle: PropTypes.object,
   layout: PropTypes.oneOf(values(CHART_LAYOUT_TYPE)),
   sign: PropTypes.string,
   signAlignment: PropTypes.string,

--- a/src/components/Sections/SectionNumber.less
+++ b/src/components/Sections/SectionNumber.less
@@ -6,6 +6,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  line-height: normal;
 
   .number-container {
     position: relative;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -69,7 +69,8 @@ export function getSectionComponent(section, maxWidth) {
         <SectionNumber
           layout={section.layout.layout}
           title={section.title}
-          titleStyle={section.titleStyle}
+          titleStyle={section.layout.titleStyle}
+          numberStyle={section.layout.numberStyle}
           data={numberData}
           sign={section.layout.currencySign || section.layout.sign}
           signAlignment={section.layout.signAlignment}

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -128,6 +128,14 @@
       "style": {
         "backgroundColor": null
       },
+      "numberStyle": {
+        "fontSize": "40px",
+        "fontWeight": 300
+      },
+      "titleStyle": {
+        "fontSize": "34px",
+        "fontWeight": 400
+      },
       "w": 3,
       "valuesFormat": "decimal"
     },

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -440,6 +440,10 @@ describe('Report Container', () => {
     expect(trendNumber.at(0).find('.trend-num-text').text()).to
       .equal(formatNumberValue(sec2.data.currSum, sec2.layout.valuesFormat));
     expect(trendNumber.at(0).props().layout).to.equal(sec2.layout.layout);
+    expect(trendNumber.at(0).props().numberStyle).to.deep.equal(sec2.layout.numberStyle);
+    expect(trendNumber.at(0).props().titleStyle).to.deep.equal(sec2.layout.titleStyle);
+    expect(trendNumber.at(0).find('.trend-num-text').prop('style')).to.contain(sec2.layout.numberStyle);
+    expect(trendNumber.at(0).find('.trend-message').prop('style')).to.contain(sec2.layout.titleStyle);
     const trendBox = trendNumber.at(0).find('.trend-box.green');
     expect(trendBox).to.have.length(1);
 


### PR DESCRIPTION
_Related to https://github.com/demisto/web-client/pull/8339_

Applies given style objects under layout over number/trend widgets.
→ numberStyle & titleStyle properties

**Example:**
```
{
    "type": "trend",
    "data": {
      "currSum": 5,
      "prevSum": 49
    },
    "layout": {
      "columnPos": 2,
      "currencySign": "",
      "h": 1,
      "i": "0c22b3d0-f5eb-11e7-92ea-eb1e1a874380",
      "layout": "horizontal",
      "rowPos": 0,
      "style": {
        "backgroundColor": null
      },
      "numberStyle": {
        "fontSize": "40px",
        "fontWeight": 300
      },
      "titleStyle": {
        "fontSize": "34px",
        "fontWeight": 400
      },
      "w": 3,
      "valuesFormat": "decimal"
    },
    "query": {
      "filter": {
        "period": {
          "fromValue": 30,
          "by": "day"
        },
        "fromDate": "2017-12-10T22:00:00Z",
        "toDate": null
      }
    },
    "automation": {
      "name": "",
      "args": null
    },
    "title": "Trend Chart"
  }
```

**Out:**
![image](https://user-images.githubusercontent.com/11019955/121159695-13354b80-c854-11eb-8802-57f8e8212bb4.png)
