### PR TITLE
optional table headers styling object

### DIFF
--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -8,7 +8,7 @@ import SectionTitle from './SectionTitle';
 
 
 const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, classes, style, title, titleStyle, emptyString,
-  maxColumns, forceRangeMessage }) => {
+  maxColumns, forceRangeMessage, headerStyle }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -56,6 +56,10 @@ const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, classes
 
               if (metaData) {
                 extraProps.width = metaData.width;
+              }
+
+              if (headerStyle) {
+                extraProps.style = headerStyle;
               }
 
               return (
@@ -109,7 +113,14 @@ const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, classes
             <tr>
               {readyColumns.map((col) => {
               const key = col.key || col;
-              return <th key={key}>{!col.hidden && ((readableHeaders && readableHeaders[key]) || key)}</th>;
+                return (
+                  <th
+                    key={key}
+                    {...(headerStyle ? { style: headerStyle } : {})}
+                  >
+                    {!col.hidden && ((readableHeaders && readableHeaders[key]) || key)}
+                  </th>
+                );
             })}
             </tr>
           </thead>
@@ -155,7 +166,8 @@ SectionTable.propTypes = {
   maxColumns: PropTypes.number,
   titleStyle: PropTypes.object,
   emptyString: PropTypes.string,
-  forceRangeMessage: PropTypes.string
+  forceRangeMessage: PropTypes.string,
+  headerStyle: PropTypes.object
 };
 
 export default SectionTable;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -202,6 +202,7 @@ export function getSectionComponent(section, maxWidth) {
           maxColumns={section.layout.maxColumns || (maxWidth ? maxWidth / 100 : 0)}
           emptyString={section.emptyNotification || getDefaultEmptyNotification()}
           forceRangeMessage={section.layout.forceRangeMessage}
+          headerStyle={section.layout.headerStyle}
         />
       );
       break;

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -905,7 +905,10 @@
         "bbb"
       ],
       "w": 12,
-      "forceRangeMessage": "Last 7 days"
+      "forceRangeMessage": "Last 7 days",
+      "headerStyle": {
+        "color": "maroon"
+      }
     },
     "title": "table"
   },

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -516,6 +516,7 @@ describe('Report Container', () => {
     widgetProps = widget.props();
 
     expect(widgetProps.columns).to.equal(sec11.layout.tableColumns);
+    expect(widgetProps.headerStyle).to.equal(sec11.layout.headerStyle);
     expect(widgetProps.data).to.equal(sec11.data);
     expect(widgetProps.classes).to.equal(sec11.layout.classes);
 
@@ -528,6 +529,7 @@ describe('Report Container', () => {
     expect(tableHeader).to.have.length(2);
     expect(tableHeader.at(0).text()).to.equal(sec11.layout.tableColumns[0]);
     expect(tableHeader.at(1).text()).to.equal(sec11.layout.tableColumns[1]);
+    expect(tableHeader.at(1).prop('style')).to.equal(sec11.layout.headerStyle);
 
     expect(sectionTable.at(2).props().columns).to.equal(sec12.layout.tableColumns);
     expect(sectionTable.at(2).props().data).to.equal(sec12.data);


### PR DESCRIPTION
Fixes https://github.com/demisto/etc/issues/38641

Given:
```
{
    "type": "table",
    "data": [
      {
        ...
      }
    ],
    "layout": {
      ...
      "headerStyle": {
        "color": "maroon"
      }
    },
    ...
  }
```
**→**
![image](https://user-images.githubusercontent.com/11019955/123596231-8cdcab80-d7fa-11eb-9986-89f77029872f.png)
