### PR TITLE
pie section change vertical legend text-value layout

### DIFF
--- a/src/components/Sections/SectionChart/ChartLegend.less
+++ b/src/components/Sections/SectionChart/ChartLegend.less
@@ -18,12 +18,15 @@
     &:not(.horizontal) {
       display: flex;
       justify-content: space-between;
-    .recharts-legend-item-text {
-      flex: 2;
-      text-overflow: ellipsis;
-      white-space: nowrap;
-      overflow: hidden;
-    }
+      .recharts-legend-item-text {
+        flex: 2;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        overflow: hidden;
+      }
+      .recharts-legend-item-value {
+        flex: unset;
+      }
   }
     .recharts-legend-icon-container {
       display: inline-block;

--- a/src/components/Sections/SectionChart/SectionPieChart.less
+++ b/src/components/Sections/SectionChart/SectionPieChart.less
@@ -10,6 +10,14 @@
 
     .customized-legend {
       padding: 10px 0;
+
+      .recharts-legend-item {
+        &:not(.horizontal) {
+          .recharts-legend-item-text {
+            flex: 4;
+          }
+        }
+      }
     }
   }
 

--- a/src/components/Sections/SectionChart/SectionPieChart.less
+++ b/src/components/Sections/SectionChart/SectionPieChart.less
@@ -10,14 +10,6 @@
 
     .customized-legend {
       padding: 10px 0;
-
-      .recharts-legend-item {
-        &:not(.horizontal) {
-          .recharts-legend-item-text {
-            flex: 4;
-          }
-        }
-      }
     }
   }
 


### PR DESCRIPTION
## Status
- [x] Ready

## Related Issues
Related https://github.com/demisto/etc/issues/39562

## Description
Pie section with vertical legend layout - change flex ration between text and value to 4:1 instead 2:1 

## Screenshots

**Before**
![image](https://user-images.githubusercontent.com/76961496/128147038-95a08aac-53a0-4375-8532-71eae8e1802d.png)


**After**
![image](https://user-images.githubusercontent.com/76961496/128146716-9f2f3b38-0272-4c24-8c0f-044f7899aecd.png)

![image](https://user-images.githubusercontent.com/76961496/128150749-c921c3a2-bb0b-454b-bd43-a0e23babce55.png)

### WEB-LAYOUT
![image](https://user-images.githubusercontent.com/76961496/128321655-0986acfb-126e-4785-84a3-9fad1d549621.png)

### REPORT-LAYOUT
![image](https://user-images.githubusercontent.com/76961496/128322528-dff34078-ffda-40cf-b7d6-bbfafab367e2.png)

