### PR TITLE
markdown images support

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -10,6 +10,7 @@
     var reportDimensions = '{report-dimensions}';
     var reportData = '{report-data-to-replace}';
     var forceAutoHeightLayout = '{force-auto-height}';
+    var markdownArtifactsServerAddress = '{md-server-address-to-replace}';
   </script>
   <body>
     <div id="app"></div>

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -1,5 +1,8 @@
 /* eslint-disable */
 /* This file is deprecated and used as legacy only */
+import {
+  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS
+} from '../src/constants/Constants';
 const evalsFunctions = require('./evals');
 const puppeteer = require('puppeteer');
 const chromePath = require('@moonandyou/chrome-path');
@@ -69,6 +72,7 @@ const BOTTOM_MARGIN = 40;
   const disableHeaders = process.argv[12] === true || process.argv[12] === "true";
   const chromeExecution = process.argv[13] || paths['chromium'] || paths['google-chrome-stable'] || paths['google-chrome'] || '/usr/bin/chromium-browser';
   const forceAutoHeightLayout = process.argv[14] === true || process.argv[14] === "true";
+  const markdownArtifactsServerAddress = process.argv[15] || MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS;
   let browser;
 
   if (headerLeftImage && headerLeftImage.indexOf('data:image') === -1) {
@@ -99,7 +103,8 @@ const BOTTOM_MARGIN = 40;
             .replace('{report-header-image-left}', headerLeftImage)
             .replace('{report-header-image-right}', headerRightImage)
             .replace('{report-dimensions}', JSON.stringify({ height: dimensions.height, width: dimensions.width }))
-            .replace('{force-auto-height}', !!forceAutoHeightLayout);
+            .replace('{force-auto-height}', !!forceAutoHeightLayout)
+            .replace('{md-server-address-to-replace}', markdownArtifactsServerAddress);
     const loadedData = fs.readFileSync(dataFile).toString();
 
     // $ is a special character in string replace, see here: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -1,8 +1,5 @@
 /* eslint-disable */
 /* This file is deprecated and used as legacy only */
-import {
-  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS
-} from '../src/constants/Constants';
 const evalsFunctions = require('./evals');
 const puppeteer = require('puppeteer');
 const chromePath = require('@moonandyou/chrome-path');
@@ -72,7 +69,7 @@ const BOTTOM_MARGIN = 40;
   const disableHeaders = process.argv[12] === true || process.argv[12] === "true";
   const chromeExecution = process.argv[13] || paths['chromium'] || paths['google-chrome-stable'] || paths['google-chrome'] || '/usr/bin/chromium-browser';
   const forceAutoHeightLayout = process.argv[14] === true || process.argv[14] === "true";
-  const markdownArtifactsServerAddress = process.argv[15] || MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS;
+  const markdownArtifactsServerAddress = process.argv[15] || '';
   let browser;
 
   if (headerLeftImage && headerLeftImage.indexOf('data:image') === -1) {

--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types';
 import { mdReact } from 'react-markdown-demisto';
 import Highlight from 'react-highlight';
 import isString from 'lodash/isString';
-import { PAGE_BREAK_KEY } from '../../constants/Constants';
+import { MARKDOWN_IMAGES_PATH, PAGE_BREAK_KEY } from '../../constants/Constants';
 import { mdBtn, mdTextAlign, mdTextStyle, mdUnderline } from '../../utils/markdown';
 import WidgetEmptyState from './WidgetEmptyState';
 
@@ -35,7 +35,8 @@ export default class SectionMarkdown extends Component {
       PropTypes.object,
       PropTypes.string
     ]),
-    forceRangeMessage: PropTypes.string
+    forceRangeMessage: PropTypes.string,
+    markdownArtifactsServerAddress: PropTypes.string
   };
 
   static createBtn(props, children) {
@@ -49,7 +50,7 @@ export default class SectionMarkdown extends Component {
     return (<span {...props}>{message}</span>);
   }
 
-  static handleIterate(tableClasses, Tag, props, children) {
+  static handleIterate(tableClasses, markdownArtifactsServerAddress, Tag, props, children) {
     let res = '';
     switch (Tag) {
       case 'textalign': {
@@ -76,7 +77,11 @@ export default class SectionMarkdown extends Component {
       }
       case 'img': {
         const srcArr = props.src.split('=size=');
-        props.src = srcArr[0];
+        if (srcArr[0].startsWith(MARKDOWN_IMAGES_PATH)) {
+          props.src = `${markdownArtifactsServerAddress}${srcArr[0]}`;
+        } else {
+          props.src = srcArr[0];
+        }
         if (srcArr.length > 1) {
           const sizeArr = srcArr[1].split('x');
           props.height = sizeArr[0];
@@ -176,7 +181,16 @@ export default class SectionMarkdown extends Component {
   }
 
   render() {
-    const { text, style, tableClasses, doNotShowEmoji, setRef, customClass, forceRangeMessage } = this.props;
+    const {
+      text,
+      style,
+      tableClasses,
+      doNotShowEmoji,
+      setRef,
+      customClass,
+      forceRangeMessage,
+      markdownArtifactsServerAddress
+    } = this.props;
     let finalText = text;
     IGNORE_KEYS.forEach((s) => {
       finalText = (finalText || '').replace(s, '');
@@ -204,7 +218,7 @@ export default class SectionMarkdown extends Component {
 
       const mdData = mdReact(
         {
-          onIterate: SectionMarkdown.handleIterate.bind(this, tableClasses),
+          onIterate: SectionMarkdown.handleIterate.bind(this, tableClasses, markdownArtifactsServerAddress),
           markdownOptions: { typographer: true },
           plugins
         }

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -1,7 +1,6 @@
 export const REPORT_DATA_TOKEN = '{report-data-to-replace}';
 export const REPORT_HEADER_IMAGE_RIGHT_TOKEN = '{report-header-image-right}';
 export const REPORT_HEADER_IMAGE_LEFT_TOKEN = '{report-header-image-left}';
-export const MD_ARTIFACTS_SERVER_ADDRESS_TOKEN = '{md-server-address-to-replace}';
 
 
 export const SECTION_TYPES = {
@@ -198,6 +197,5 @@ export const DATA_TYPES = {
   incident: 'incident'
 };
 
-export const MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS = 'http://localhost:10888';
 export const MARKDOWN_IMAGES_PATH = '/markdown/image';
 

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -1,6 +1,7 @@
 export const REPORT_DATA_TOKEN = '{report-data-to-replace}';
 export const REPORT_HEADER_IMAGE_RIGHT_TOKEN = '{report-header-image-right}';
 export const REPORT_HEADER_IMAGE_LEFT_TOKEN = '{report-header-image-left}';
+export const MD_ARTIFACTS_SERVER_ADDRESS_TOKEN = '{md-server-address-to-replace}';
 
 
 export const SECTION_TYPES = {
@@ -196,4 +197,7 @@ export const INCIDENT_SEVERITY = {
 export const DATA_TYPES = {
   incident: 'incident'
 };
+
+export const MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS = 'http://localhost:10888';
+export const MARKDOWN_IMAGES_PATH = '/markdown/image';
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,8 +12,7 @@ import * as TemplateProvider from '../templates/templateProvider';
 import {
   REPORT_DATA_TOKEN,
   REPORT_TYPES,
-  PIXEL_SIZE,
-  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS, MD_ARTIFACTS_SERVER_ADDRESS_TOKEN
+  PIXEL_SIZE
 } from './constants/Constants';
 import { prepareSections, getReportType } from './utils/reports';
 import { generateOfficeReport } from './office/OfficeReport';
@@ -24,10 +23,8 @@ if (data === REPORT_DATA_TOKEN) {
 }
 
 const type = getReportType(reportType);
-const mdArtifactsServerAddress = markdownArtifactsServerAddress === MD_ARTIFACTS_SERVER_ADDRESS_TOKEN ?
-  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS : markdownArtifactsServerAddress;
 
-const sections = prepareSections(data, type, false, false, mdArtifactsServerAddress);
+const sections = prepareSections(data, type, false, false, markdownArtifactsServerAddress);
 
 let isLayout = false;
 if (sections) {

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import ReportContainer from './containers/ReportContainer';
 import * as TemplateProvider from '../templates/templateProvider';
-import { REPORT_DATA_TOKEN, REPORT_TYPES, PIXEL_SIZE } from './constants/Constants';
+import {
+  REPORT_DATA_TOKEN,
+  REPORT_TYPES,
+  PIXEL_SIZE,
+  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS, MD_ARTIFACTS_SERVER_ADDRESS_TOKEN
+} from './constants/Constants';
 import { prepareSections, getReportType } from './utils/reports';
 import { generateOfficeReport } from './office/OfficeReport';
 
@@ -19,7 +24,10 @@ if (data === REPORT_DATA_TOKEN) {
 }
 
 const type = getReportType(reportType);
-const sections = prepareSections(data, type);
+const mdArtifactsServerAddress = markdownArtifactsServerAddress === MD_ARTIFACTS_SERVER_ADDRESS_TOKEN ?
+  MARKDOWN_ARTIFACTS_DEFAULT_SERVER_ADDRESS : markdownArtifactsServerAddress;
+
+const sections = prepareSections(data, type, false, false, mdArtifactsServerAddress);
 
 let isLayout = false;
 if (sections) {

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -133,6 +133,7 @@ export function getSectionComponent(section, maxWidth) {
           doNotShowEmoji={section.layout.doNotShowEmoji}
           customClass={isPageBreakSection(section) ? 'page-break-section' : ''}
           forceRangeMessage={section.layout.forceRangeMessage}
+          markdownArtifactsServerAddress={section.markdownArtifactsServerAddress}
         />
       );
       break;

--- a/src/utils/reports.js
+++ b/src/utils/reports.js
@@ -36,7 +36,13 @@ function filterSectionsAccordingToReportType(reportData, reportType) {
   });
 }
 
-export function prepareSections(reportData, reportType, autoPageBreak, reflectDimensions) {
+export function prepareSections(
+  reportData,
+  reportType,
+  autoPageBreak,
+  reflectDimensions,
+  markdownArtifactsServerAddress
+) {
   const rows = {};
 
   if (reportData) {
@@ -52,6 +58,9 @@ export function prepareSections(reportData, reportType, autoPageBreak, reflectDi
       section.autoPageBreak = autoPageBreak;
       if (reflectDimensions) {
         section.layout.reflectDimensions = true;
+      }
+      if (section.type === SECTION_TYPES.markdown) {
+        section.markdownArtifactsServerAddress = markdownArtifactsServerAddress;
       }
     });
   }


### PR DESCRIPTION
Related issue: https://github.com/demisto/etc/issues/40210

 - Support markdown resources server parameter (to be sent via sanePdfReports script)
 - translate any demisto markdown image source (hosted in demisto server) to the markdown resource server received via the cmd parameter.

## Related PRs
branch | PR
------ | ------
Content PR | https://github.com/demisto/content/pull/14508
Server MR |  https://code.pan.run/xsoar/server/-/merge_requests/16194