### PR TITLE
Style reports layout

### DIFF
--- a/src/components/Layouts/ReportLayout.js
+++ b/src/components/Layouts/ReportLayout.js
@@ -183,6 +183,10 @@ class ReportLayout extends Component {
         SECTION_TYPES.trend === section.type;
   };
 
+  shouldShowEmptyState = (section) => {
+    return section.type !== SECTION_TYPES.date && (isEmpty(section.data) || section.data.length === 0);
+  }
+
   render() {
     const { sections, headerLeftImage, headerRightImage, isLayout, dimensions } = this.props;
     return (
@@ -244,10 +248,11 @@ class ReportLayout extends Component {
                               const gridItem = ReportLayout.getGridItemFromSection(section, overflowRows);
                               overflowRows += gridItem.h - section.layout.h;
                               const disableAutoHeight = this.shouldDisableAutoHeight(section);
+                              const showEmptyState = this.shouldShowEmptyState(section);
                               const mainClass = classNames(`section-layout section-${section.type} ` +
                               `${section.layout.class || ''}`,
                                   { 'section-show-overflow': section.layout.reflectDimensions === true,
-                                    'section-show-empty-state': isEmpty(section.data) || section.data.length === 0,
+                                    'section-show-empty-state': showEmptyState,
                                     'disable-auto-height': disableAutoHeight
                                   });
 

--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -35,7 +35,11 @@
       .section-item-header {
         width: 30%;
         word-break: break-word;
-       }
+      }
+
+      &:last-child {
+        border-bottom: none;
+      }
     }
 
     .section-item-value {

--- a/src/components/Sections/SectionDate.js
+++ b/src/components/Sections/SectionDate.js
@@ -5,12 +5,12 @@ import moment from 'moment-timezone';
 
 
 const SectionDate = ({ date, style, format }) =>
-  <span className="section-date" style={style}>
+  <div className="section-date" style={style}>
     <span className="section-date-key">Date:</span>
     <span className="section-date-value">
       {date ? moment(date).tz(moment.tz.guess()).format(format) : moment().tz(moment.tz.guess()).format(format)}
     </span>
-  </span>;
+  </div>;
 SectionDate.propTypes = {
   date: PropTypes.string,
   style: PropTypes.object,

--- a/src/utils/reports.js
+++ b/src/utils/reports.js
@@ -49,12 +49,13 @@ export function prepareSections(
     reportData.sort(sortReportSections);
 
     filterSectionsAccordingToReportType(reportData, reportType).forEach((section) => {
-      if (rows[section.layout.rowPos]) {
-        rows[section.layout.rowPos].push(section);
-      } else {
-        rows[section.layout.rowPos] = [section];
-        rows[section.layout.rowPos].style = section.layout.rowStyle || {};
+      if (!rows[section.layout.rowPos]) {
+        rows[section.layout.rowPos] = [];
       }
+
+      rows[section.layout.rowPos].push(section);
+      rows[section.layout.rowPos].style = section.layout.rowStyle || {};
+
       section.autoPageBreak = autoPageBreak;
       if (reflectDimensions) {
         section.layout.reflectDimensions = true;


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] In Progress

## Related Issues

https://github.com/demisto/etc/issues/38832

## Related PRs

https://code.pan.run/xsoar/web-client/-/merge_requests/6658

## Description

Row fields: last field in section does not have a line under it
Style "date" and "generated by"

## Screenshots

## dev4

![Screen Shot 2021-08-30 at 17 15 14](https://user-images.githubusercontent.com/73780437/131353439-b3b159a6-fbe5-4abd-bd91-a8a97bf18eeb.png)

## update-reports-layout-3

![Screen Shot 2021-09-05 at 19 06 04](https://user-images.githubusercontent.com/73780437/132133582-ac818ec9-6bcc-4dbd-aa5a-84a4e16f8d1c.png)
![Screen Shot 2021-09-05 at 19 21 41](https://user-images.githubusercontent.com/73780437/132134026-6cc4c78e-e68e-447b-922b-17ed5800cc1e.png)




