### PR TITLE
Style reports layout

### DIFF
--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -147,30 +147,29 @@ const BOTTOM_MARGIN = 40;
           margin: {top: topMargin, bottom: BOTTOM_MARGIN},
           displayHeaderFooter: true,
           headerTemplate: !disableHeaders ? "" + "<div style='" +
-              "height: 200px;" +
-              "font-size: 10px;" +
-              "width: 100%;" +
-              "margin-top: -7px;" +
-              "margin-right: -10px;" +
-              "margin-left: -10px;" +
-              "padding-top: 13px;" +
-              "padding-right: 20px;" +
-              "padding-left: 20px;'" +
-              ">" +
-              "<div style='text-align: left; float: left'>" +
-              "<img src=\"" + headerLeftImage + "\" height='20px'/>" +
-              "</div>" +
-              "<div style='text-align: right; float: right'>" +
-              "<img src=\"" + headerRightImage + "\" height='20px'/>" +
-              "</div>" +
-              "</div>" : '',
+            "height: 200px;" +
+            "font-size: 10px;" +
+            "width: 100%;" +
+            "margin-top: -7px;" +
+            "margin-right: -10px;" +
+            "margin-left: -10px;" +
+            "padding-top: 13px;" +
+            "padding-right: 20px;" +
+            "padding-left: 20px;'" +
+            ">" +
+            "<div style='text-align: left; float: left'>" +
+            "<img src=\"" + headerLeftImage + "\" height='20px'/>" +
+            "</div>" +
+            "<div style='text-align: right; float: right'>" +
+            "<img src=\"" + headerRightImage + "\" height='20px'/>" +
+            "</div>" +
+            "</div>" : '',
           footerTemplate: `
-      <div style="font-size:12px!important;width:100%;margin: 0 auto;color:grey!important;padding-left:10px;text-align:center;" class="footer">
-      ${headerLeftImage && disableHeaders ? '<img style="float: left;height: 10px;width: auto;margin: 0 10px;" src='+ headerLeftImage +' />' : ''}
-      ${headerRightImage && disableHeaders ? '<img style="float: right;height: 10px;width: auto;margin: 0 10px;" src='+ headerRightImage +' />' : ''}
-<span class="pageNumber"></span>/<span class="totalPages"></span>
-</div>
-  `,
+            <div style="font-size:12px!important;width:100%;margin: 0 auto;color:rgba(40, 41 , 42, 0.7)!important;padding-left:10px;text-align:center;" class="footer">
+              ${headerLeftImage && disableHeaders ? '<img style="float: left;height: 10px;width: auto;margin: 0 10px;" src='+ headerLeftImage +' />' : ''}
+              ${headerRightImage && disableHeaders ? '<img style="float: right;height: 10px;width: auto;margin: 0 10px;" src='+ headerRightImage +' />' : ''}
+              <span class="pageNumber"></span>/<span class="totalPages"></span>
+            </div>`,
           landscape: orientation === PAGE_ORIENTATION.landscape
         });
         break;

--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -124,7 +124,8 @@ h1 {
       }
 
       .section-item-value {
-        .section-markdown {
+        .section-markdown,
+        .section-table {
           border: none;
           padding: 0;
         }

--- a/src/components/Sections/ItemsSection.js
+++ b/src/components/Sections/ItemsSection.js
@@ -1,4 +1,5 @@
 import './ItemsSection.less';
+import classNames from 'classnames';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { SECTION_ITEMS_DISPLAY_LAYOUTS, SECTION_ITEM_TYPE } from '../../constants/Constants';
@@ -114,6 +115,7 @@ class ItemsSection extends Component {
       <AutoSizer disableHeight>
         {({ width }) => {
           const columnWidth = width / columns;
+          const maxRow = maxBy(items, item => item.index).index;
           return (
             <div className="items-section" style={{ width, height: maxOffset, ...style }}>
               {title && <div className="section-title" style={titleStyle}>{title}</div>}
@@ -132,7 +134,14 @@ class ItemsSection extends Component {
               {(items || []).map((item) => {
                 const colSpan = this.getItemColSpan(item);
                 const id = this.getSectionItemKey(item);
-                const mainClass = `section-item ${(item.displayType || '').toLowerCase()}`;
+                const displayTypeClass = (item.displayType || '').toLowerCase();
+                const isCard = displayTypeClass === SECTION_ITEMS_DISPLAY_LAYOUTS.card;
+                const mainClass = classNames('section-item', {
+                  [displayTypeClass]: true,
+                  'first-column': isCard && item.startCol === 0,
+                  'last-column': isCard && item.endCol === columns,
+                  'last-row': isCard && item.index === maxRow
+                });
                 const applyStyle = {
                   transform:
                     `translate(${item.startCol * columnWidth}px, ${ItemsSection.getHeightOffset(columnUsage, item)}px)`,
@@ -144,7 +153,7 @@ class ItemsSection extends Component {
                 if (type === SECTION_ITEM_TYPE.html) {
                   dataDisplay = <SectionHTML text={item.data} />;
                 } else if (type === SECTION_ITEM_TYPE.tagsSelect) {
-                  dataDisplay = <SectionTags tags={item.data} />
+                  dataDisplay = <SectionTags tags={item.data} />;
                 }
 
                 return (

--- a/src/components/Sections/ItemsSection.js
+++ b/src/components/Sections/ItemsSection.js
@@ -34,6 +34,10 @@ class ItemsSection extends Component {
     return get(columnUsage, `${item.startCol}.${item.index}.offset`, 0);
   }
 
+  static getItemDisplayType(item) {
+    return (item.displayType || '').toLowerCase();
+  }
+
   constructor(props) {
     super(props);
 
@@ -95,10 +99,6 @@ class ItemsSection extends Component {
     return colSpan === 0 ? columns : colSpan;
   }
 
-  getItemDisplayType(item) {
-    return (item.displayType || '').toLowerCase();
-  }
-
   render() {
     const { style, items, columns, title, titleStyle, description } = this.props;
     const { columnUsage } = this.state;
@@ -121,7 +121,7 @@ class ItemsSection extends Component {
           const columnWidth = width / columns;
           const lastRowIndex = maxBy(items, item => item.index).index;
           const allItemsAreDisplayedAsCards = every(items,
-            item => this.getItemDisplayType(item) === SECTION_ITEMS_DISPLAY_LAYOUTS.card
+            item => ItemsSection.getItemDisplayType(item) === SECTION_ITEMS_DISPLAY_LAYOUTS.card
           );
 
           return (
@@ -145,7 +145,7 @@ class ItemsSection extends Component {
               {(items || []).map((item) => {
                 const colSpan = this.getItemColSpan(item);
                 const id = this.getSectionItemKey(item);
-                const itemDisplayType = this.getItemDisplayType(item);
+                const itemDisplayType = ItemsSection.getItemDisplayType(item);
                 const mainClass = classNames('section-item', {
                   [itemDisplayType]: true,
                   'first-column': allItemsAreDisplayedAsCards && item.startCol === 0,

--- a/src/components/Sections/ItemsSection.js
+++ b/src/components/Sections/ItemsSection.js
@@ -3,7 +3,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { SECTION_ITEMS_DISPLAY_LAYOUTS, SECTION_ITEM_TYPE } from '../../constants/Constants';
 import { AutoSizer } from 'react-virtualized';
-import { SectionHTML, SectionMarkdown, SectionTable } from './index';
+import { SectionHTML, SectionMarkdown, SectionTable, SectionTags } from './index';
 import { get, maxBy } from 'lodash';
 import uuid from 'uuid';
 import { sortByFieldsWithPriority } from '../../utils/sort';
@@ -143,6 +143,8 @@ class ItemsSection extends Component {
                 <SectionMarkdown text={String(item.data)} />;
                 if (type === SECTION_ITEM_TYPE.html) {
                   dataDisplay = <SectionHTML text={item.data} />;
+                } else if (type === SECTION_ITEM_TYPE.tagsSelect) {
+                  dataDisplay = <SectionTags tags={item.data} />
                 }
 
                 return (

--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -21,18 +21,6 @@
         padding-bottom: 9px;
         word-break: break-word;
       }
-
-      &:not(.first-column) {
-        padding-left: 15px;
-      }
-
-      &:not(.last-column) {
-        padding-right: 15px;
-      }
-
-      &:not(.last-row) {
-        padding-bottom: 30px;
-      }
     }
 
     &.row {
@@ -56,6 +44,24 @@
       flex: 1;
       white-space: pre-line;
       word-break: break-word;
+    }
+  }
+
+  &.cards-container {
+    .section-item {
+      &.card {
+        &:not(.first-column) {
+          padding-left: 15px;
+        }
+
+        &:not(.last-column) {
+          padding-right: 15px;
+        }
+
+        &:not(.last-row) {
+          padding-bottom: 30px;
+        }
+      }
     }
   }
 }

--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -21,6 +21,18 @@
         padding-bottom: 9px;
         word-break: break-word;
       }
+
+      &:not(.first-column) {
+        padding-left: 15px;
+      }
+
+      &:not(.last-column) {
+        padding-right: 15px;
+      }
+
+      &:not(.last-row) {
+        padding-bottom: 30px;
+      }
     }
 
     &.row {

--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -17,8 +17,6 @@
     min-height: 50px;
 
     &.card {
-      padding-bottom: 30px;
-
       .section-item-header {
         padding-bottom: 9px;
         word-break: break-word;

--- a/src/components/Sections/SectionTable.less
+++ b/src/components/Sections/SectionTable.less
@@ -1,10 +1,32 @@
 .section-table {
   overflow-x: hidden;
+  margin-top: 0 !important;
 
   thead {
     th {
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+  }
+
+  th, td {
+    border-top: 1px solid #DADBDB !important;
+    border-left: 1px solid #DADBDB !important;
+    border-bottom: none !important;
+    border-right: none !important;
+
+    &:empty {
+      height: 35px !important;
+    }
+
+    &:last-child {
+      border-right: 1px solid #DADBDB !important;
+    }
+  }
+
+  tr:last-child {
+    td {
+      border-bottom:  1px solid #DADBDB !important;
     }
   }
 }

--- a/src/components/Sections/SectionTags.js
+++ b/src/components/Sections/SectionTags.js
@@ -1,0 +1,15 @@
+/* eslint-disable react/no-danger */
+import './SectionTags.less';
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const SectionTags = ({ tags }) =>
+  <div className="section-tags">
+    { tags.split(',').map(tag => <span key={tag} className="tag-item">{tag}</span>) }
+  </div>;
+
+SectionTags.propTypes = {
+  tags: PropTypes.string
+};
+
+export default SectionTags;

--- a/src/components/Sections/SectionTags.less
+++ b/src/components/Sections/SectionTags.less
@@ -1,0 +1,17 @@
+.section-tags {
+  .tag-item {
+    box-sizing: border-box;
+    display: inline-block;
+    font-size: 12px;
+    line-height: 18px;
+    color: white;
+    padding: 0 5px;
+    margin-right: 4px;
+    border-radius: 10px;
+    background-color: #768ba1;
+    max-width: 175px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}

--- a/src/components/Sections/index.js
+++ b/src/components/Sections/index.js
@@ -13,3 +13,4 @@ export { default as SectionGroupedList } from './SectionGroupedList';
 export { default as SectionDuration } from './SectionDuration';
 export { default as ItemsSection } from './ItemsSection';
 export { default as SectionHTML } from './SectionHTML';
+export { default as SectionTags } from './SectionTags';

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -151,7 +151,8 @@ export const SECTION_ITEMS_DISPLAY_LAYOUTS = {
 
 export const SECTION_ITEM_TYPE = {
   html: 'html',
-  text: 'text'
+  text: 'text',
+  tagsSelect: 'tagsSelect'
 };
 
 export const PAGE_BREAK_KEY = '\\pagebreak';


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] In Progress

## Related Issues

https://github.com/demisto/etc/issues/38832

## Description
Style reports layout:
- style pagination numbers in the PDF
- style grid items and tags
- adding paddings between card items inside sections (see timeline-information) and removing redundant paddings from other elements 

## Screenshots

## master
![Screen Shot 2021-09-09 at 18 30 35](https://user-images.githubusercontent.com/73780437/132716181-6194ba1b-22ac-4a57-8635-0ba28ed75ab3.png)
![Screen Shot 2021-09-09 at 18 29 57](https://user-images.githubusercontent.com/73780437/132716188-6bcb89de-162d-439b-9073-f3c0bbf06670.png)


## style-report-layout

![Screen Shot 2021-09-09 at 18 18 57](https://user-images.githubusercontent.com/73780437/132714351-50df208a-bdc0-407b-980c-f02a878a6326.png)
![Screen Shot 2021-09-09 at 18 16 27](https://user-images.githubusercontent.com/73780437/132714362-c4139213-d80c-488d-9be9-ff945171da07.png)

