### PR TITLE
Style reports layout

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -120,8 +120,9 @@ h1 {
       .section-item-value {
         .section-markdown,
         .section-table {
-          border: none;
-          padding: 0;
+          border: none !important;
+          padding: 0 !important;
+          margin-top: 0;
         }
       }
 

--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -26,10 +26,10 @@
 
   .preplacer {
     display: block;
-    margin-block-start: 1em;
-    margin-block-end: 1em;
-    margin-inline-start: 0px;
-    margin-inline-end: 0px;
+    margin-block-start: 1.1em;
+    margin-block-end: 1.1em;
+    margin-inline-start: 0;
+    margin-inline-end: 0;
 
     &:last-child {
       margin-bottom: 0 !important;

--- a/src/components/Sections/SectionTable.less
+++ b/src/components/Sections/SectionTable.less
@@ -1,6 +1,5 @@
 .section-table {
   overflow-x: hidden;
-  margin-top: 0 !important;
   height: 100%;
 
   thead {


### PR DESCRIPTION
## Status

- [x] Ready
- [ ] In Progress

## Related Issues

https://github.com/demisto/etc/issues/38832

## Description
Style reports layout:
- fix titles bottom margins 
- fix grid fields redundant borders
- fix date was truncated in the generated pdf report

## Screenshots (before)
![Screen Shot 2021-09-19 at 16 12 00](https://user-images.githubusercontent.com/73780437/133928936-06e93fe8-0c85-4ead-b446-d193855312a9.png)
![Screen Shot 2021-09-19 at 16 09 14](https://user-images.githubusercontent.com/73780437/133928946-5fd6047a-5927-4a45-a0db-96145249f1c9.png)

## Screenshots (after)
![Screen Shot 2021-09-19 at 16 13 04](https://user-images.githubusercontent.com/73780437/133928945-3289f346-4c36-47d2-8712-fbf40f4a66f7.png)
![Screen Shot 2021-09-19 at 16 08 55](https://user-images.githubusercontent.com/73780437/133928939-c5d372ae-5a32-44d1-823d-afae3d43d495.png)
