### PR TITLE
display chart legend percentage with precision

### DIFF
--- a/src/components/Sections/SectionChart/ChartLegend.js
+++ b/src/components/Sections/SectionChart/ChartLegend.js
@@ -47,7 +47,7 @@ const ChartLegend = ({ data, icon = 'square', layout = CHART_LAYOUT_TYPE.vertica
     let width = 'auto';
     const rawValue = group.value || 0;
     const value = formatter ? formatter(rawValue) : rawValue;
-    const percentage = group.percentage ? `${Math.round(group.percentage)}%` : undefined;
+    const percentage = group.percentage ? `${group.percentage.toFixed(2)}%` : undefined;
     // decrease width of name (if value exists) to allow for ellipsis.
     if (showValue) {
       if (valueDisplay === VALUE_FORMAT_TYPES.stretch) {


### PR DESCRIPTION
## Status

- [x] Ready

## Related Issues

Fixes https://github.com/demisto/etc/issues/41526

## Description

Add fixed precision (2) to chart legend percentage

## Screenshots

<img width="838" alt="Screen Shot 2021-10-05 at 11 29 16" src="https://user-images.githubusercontent.com/76961496/135991174-c5900cb9-da18-4e6a-b4cf-ece702f5868a.png">
<img width="838" alt="Screen Shot 2021-10-05 at 11 30 19" src="https://user-images.githubusercontent.com/76961496/135991184-167fea3f-fa3a-4832-bc80-e29b1261460c.png">


