### PR TITLE
adding inline-blockquote functionality

### DIFF
--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -8,7 +8,7 @@ import Highlight from 'react-highlight';
 import isString from 'lodash/isString';
 import { uniqueId } from 'lodash';
 import { MARKDOWN_IMAGES_PATH, PAGE_BREAK_KEY } from '../../constants/Constants';
-import { mdBtn, mdTextAlign, mdTextStyle, mdUnderline } from '../../utils/markdown';
+import { mdBtn, mdHyper, mdTextAlign, mdTextStyle, mdUnderline, myBackticks } from '../../utils/markdown';
 import WidgetEmptyState from './WidgetEmptyState';
 
 // plugins for react markdown component
@@ -160,6 +160,10 @@ export default class SectionMarkdown extends Component {
       case 'blockquote':
         props.className = 'markdown blockquote';
         break;
+      case 'inlineCode':
+        props.className = 'markdown inline-blockquote';
+        res = <span {...props}>{children}</span>;
+        break;
       case 'br':
         res = <span {...props}><br /></span>;
         break;
@@ -204,6 +208,10 @@ export default class SectionMarkdown extends Component {
     let res = finalText;
     try {
       const plugins = [
+        myBackticks,
+        mdUnderline,
+        mdTextAlign,
+        mdTextStyle,
         abbr,
         sub,
         sup,
@@ -213,9 +221,7 @@ export default class SectionMarkdown extends Component {
         deflist,
         ins,
         mdBtn,
-        mdUnderline,
-        mdTextAlign,
-        mdTextStyle
+        mdHyper
       ];
 
       if (!doNotShowEmoji) {
@@ -224,6 +230,7 @@ export default class SectionMarkdown extends Component {
 
       const mdData = mdReact(
         {
+          disableRules: ['backticks'],
           onIterate: SectionMarkdown.handleIterate.bind(this, tableClasses, markdownArtifactsServerAddress),
           markdownOptions: { typographer: true },
           plugins

--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -22,6 +22,12 @@
       color: #777;
       border-left: 4px solid @brand-color;
     }
+    &.inline-blockquote{
+      color: @markdown-inline-blockquote-color;
+      background-color: @markdown-inline-blockquote-bg-color;
+      border-radius: 3px;
+      padding: 0;
+    }
   }
 
   .preplacer {

--- a/src/css/variables.less
+++ b/src/css/variables.less
@@ -54,3 +54,6 @@
 @color-description:                     rgba(64, 65, 66, 0.7);
 
 @icon-status-noresults-24-r: data-uri('@{images-folder}/status-noresults-24-r.svg') no-repeat center;
+
+@markdown-inline-blockquote-color: @color-text;
+@markdown-inline-blockquote-bg-color: rgba(64, 65, 66, 0.08);

--- a/templates/testLayoutMarkdownWithCodeBlock.json
+++ b/templates/testLayoutMarkdownWithCodeBlock.json
@@ -6,7 +6,7 @@
         "fieldId": "bodycampaign",
         "fieldName": "Body Campaign",
         "fieldType": "markdown",
-        "data": "## Indicators of Compromise\n#### Excel file with macros for BazarLoader, \nSHA256 hash: `8662d511c7f1bef3a6e4f6d72965760345b57ddf0de5d3e6eae4e610216a39c1`\nFile size: 332,087 bytes\nFile name: `Documents new.xlsb`",
+        "data": "## Indicators of Compromise\n#### Excel file with macros for BazarLoader, \nSHA256 hash: ```8662d511c7f1bef3a6e4f6d72965760345b57ddf0de5d3e6eae4e610216a39c1```\nFile size: 332,087 bytes\nFile name: ```Documents new.xlsb```",
         "headerStyle": {
           "color": "rgba(64, 65, 66, 0.7)",
           "fontSize": "14px",

--- a/templates/testLayoutMarkdownWithCodeBlock2.json
+++ b/templates/testLayoutMarkdownWithCodeBlock2.json
@@ -1,0 +1,47 @@
+[
+  {
+    "type": "itemsSection",
+    "data": [
+      {
+        "fieldId": "bodycampaign",
+        "fieldName": "Body Campaign",
+        "fieldType": "markdown",
+        "data": "## This is a header\n### This is sub header\nthis will have inline code `inline code here`\nthis will have code block ```code block```",
+        "headerStyle": {
+          "color": "rgba(64, 65, 66, 0.7)",
+          "fontSize": "14px",
+          "fontWeight": 600
+        },
+        "endCol": 6,
+        "displayType": "card",
+        "startCol": 0,
+        "index": 0
+      }
+    ],
+    "layout": {
+      "columnPos": 0,
+      "h": 2,
+      "i": "vug7e0qild-aa90b1c0-3273-11ec-b393-053bb5ecdeef",
+      "rowPos": 9,
+      "w": 12
+    },
+    "query": {
+      "type": "incident"
+    },
+    "automation": {
+      "name": "",
+      "id": "",
+      "args": null,
+      "noEvent": false
+    },
+    "emptyNotification": "No results found",
+    "displayType": "row",
+    "titleStyle": {
+      "color": "rgb(64, 65, 66)",
+      "fontSize": "20px",
+      "fontWeight": 600,
+      "paddingBottom": "20px"
+    },
+    "autoPageBreak": true
+  }
+]

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -857,7 +857,7 @@ describe('Report Container', () => {
     });
   });
 
-  describe.only('markdown back-quote: code-blocks and inline-code', () => {
+  describe('markdown back-quote: code-blocks and inline-code', () => {
     let testTemplate;
     let toRender;
     let reportContainer;

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -857,27 +857,28 @@ describe('Report Container', () => {
     });
   });
 
-  describe('markdown back-quote: code-blocks and inline-code', () => {
-    let template;
-    // eslint-disable-next-line global-require
-    const fs = require('fs');
-    // eslint-disable-next-line global-require
-    const path = require('path');
+  describe.only('markdown back-quote: code-blocks and inline-code', () => {
+    let testTemplate;
+    let toRender;
+    let reportContainer;
+    let sectionMark;
 
-    function loadTemplate(filename) {
-      return JSON.parse(fs.readFileSync(path.resolve(`./templates/${filename}`),
-        { encoding: 'utf8' }));
-    }
+    before(() => {
+      testTemplate = loadTemplate('testLayoutMarkdownWithCodeBlock2.json');
+    });
 
     beforeEach(() => {
-      template = loadTemplate('testLayoutMarkdownWithCodeBlock2.json');
+      toRender = <ReportContainer sections={prepareSections(testTemplate)} />;
+      reportContainer = mount(toRender);
+      sectionMark = reportContainer.find(SectionMarkdown);
     });
+
     it('should create code block when using ```...```', () => {
-      expect(template).not.to.be.undefined;
+      expect(sectionMark.find('.markdown.inline-blockquote')).to.have.length(1);
     });
 
     it('should create inline code when using `...`', () => {
-      expect(template).not.to.be.undefined;
+      expect(sectionMark.find('code')).to.have.length(1);
     });
   });
 });

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -854,4 +854,28 @@ describe('Report Container', () => {
       });
     });
   });
+
+  describe('markdown back-quote: code-blocks and inline-code', () => {
+    let template;
+    // eslint-disable-next-line global-require
+    const fs = require('fs');
+    // eslint-disable-next-line global-require
+    const path = require('path');
+
+    function loadTemplate(filename) {
+      return JSON.parse(fs.readFileSync(path.resolve(`./templates/${filename}`),
+        { encoding: 'utf8' }));
+    }
+
+    beforeEach(() => {
+      template = loadTemplate('testLayoutMarkdownWithCodeBlock2.json');
+    });
+    it('should create code block when using ```...```', () => {
+      expect(template).not.to.be.undefined;
+    });
+
+    it('should create inline code when using `...`', () => {
+      expect(template).not.to.be.undefined;
+    });
+  });
 });


### PR DESCRIPTION
## Need
support for inline-code when using one back-tick like so:  \`...`

## Before
![image](https://user-images.githubusercontent.com/89729679/144035200-4c537780-a512-40b6-9b25-c193d1dd06f9.png)

## After
![image](https://user-images.githubusercontent.com/89729679/144034936-9783b781-c8d7-432c-9b3b-969619a4f706.png)

## Definition of Done
- [x] Unit Tests
- [x] Manual E2E Test