### PR TITLE
add page-break-inside: avoid at .preplacer and img

### DIFF
--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -13,6 +13,7 @@
 
   img {
     max-width: 100%;
+    page-break-inside: avoid;
   }
 
   .markdown {
@@ -36,6 +37,7 @@
     margin-block-end: 1.1em;
     margin-inline-start: 0;
     margin-inline-end: 0;
+    page-break-inside: avoid;
 
     &:last-child {
       margin-bottom: 0 !important;


### PR DESCRIPTION
## Before:
![image](https://user-images.githubusercontent.com/89729679/144513072-822e084a-9c83-4a12-b021-8271c0d266eb.png)

![image](https://user-images.githubusercontent.com/89729679/144513090-4563d299-871d-420c-a3e5-1c93e172e30e.png)

[2021-12-02_23-25-15_test.pdf](https://github.com/demisto/sane-reports/files/7645463/2021-12-02_23-25-15_test.pdf)


## After:
![image](https://user-images.githubusercontent.com/89729679/144513139-e605e47b-6536-4a1f-afd9-8b7089028dcd.png)
![image](https://user-images.githubusercontent.com/89729679/144513175-edc72ec2-c713-4796-90d1-c6afbbd45624.png)
[2021-12-03_00-21-58_test.pdf](https://github.com/demisto/sane-reports/files/7645459/2021-12-03_00-21-58_test.pdf)

