### PR TITLE
page break markdown parsing

### DIFF
--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -8,7 +8,7 @@ import Highlight from 'react-highlight';
 import isString from 'lodash/isString';
 import { uniqueId } from 'lodash';
 import { MARKDOWN_IMAGES_PATH, PAGE_BREAK_KEY } from '../../constants/Constants';
-import { mdBtn, mdHyper, mdTextAlign, mdTextStyle, mdUnderline, myBackticks } from '../../utils/markdown';
+import { mdBtn, mdHyper, mdPageBreak, mdTextAlign, mdTextStyle, mdUnderline, myBackticks } from '../../utils/markdown';
 import WidgetEmptyState from './WidgetEmptyState';
 
 // plugins for react markdown component
@@ -181,6 +181,9 @@ export default class SectionMarkdown extends Component {
         );
         break;
       }
+      case 'page_break':
+        res = (<div key={uniqueId('page_break_')} className="page_break">&nbsp;</div>);
+        break;
       default:
       // Do nothing - will be set after switch
     }
@@ -208,6 +211,7 @@ export default class SectionMarkdown extends Component {
     let res = finalText;
     try {
       const plugins = [
+        mdPageBreak,
         myBackticks,
         mdUnderline,
         mdTextAlign,

--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -47,4 +47,8 @@
       margin-top: 0 !important;
     }
   }
+
+  .page_break {
+      page-break-after: always;
+  }
 }

--- a/src/utils/markdown.js
+++ b/src/utils/markdown.js
@@ -240,6 +240,26 @@ export function mdBtn(md) {
   );
 }
 
+export function mdPageBreak(md) {
+  md.inline.ruler.push(
+    'page_break',
+    (state, silent) => {
+      const regex = /<page_break\/>/;
+      const index = state.src.search(regex);
+
+      if (index > -1) {
+        if (!silent) {
+          state.push('page_break', 'page_break', 0);
+        }
+        state.src = state.src.replace(regex, '');
+        return true;
+      }
+      return false;
+    },
+    { alt: ['paragraph', 'reference', 'blockquote', 'list'] }
+  );
+}
+
 export function myBackticks(md) {
   md.inline.ruler.push(
     'mybackticks',


### PR DESCRIPTION
## NEED:
Add `<page_break/>` special tag to markdown support

## MUST TODO BEFORE MERGE:
- [ ] Remove <span> that wrap md component
![image](https://user-images.githubusercontent.com/89729679/144840446-488fe9ed-df70-4be4-8405-b2d39d7c9d4d.png)

- [ ] Remove "flex" att from md component
![image](https://user-images.githubusercontent.com/89729679/144848096-a300c1a3-9e33-4062-97c8-863767d4292e.png)
