### PR TITLE
protect all sort calls make sure its an array + test

### DIFF
--- a/src/utils/reports.js
+++ b/src/utils/reports.js
@@ -46,9 +46,13 @@ export function prepareSections(
   const rows = {};
 
   if (reportData) {
-    reportData.sort(sortReportSections);
+    let data = [];
+    if (Array.isArray(reportData)) {
+      data = reportData;
+      data.sort(sortReportSections);
+    }
 
-    filterSectionsAccordingToReportType(reportData, reportType).forEach((section) => {
+    filterSectionsAccordingToReportType(data, reportType).forEach((section) => {
       if (!rows[section.layout.rowPos]) {
         rows[section.layout.rowPos] = [];
       }

--- a/src/utils/sort.js
+++ b/src/utils/sort.js
@@ -134,7 +134,11 @@ export function sortByField(fields, asc = true) {
 }
 
 export function sortBySeverity(data) {
-  return data.sort((a, b) => {
+  let arr = data;
+  if (!Array.isArray(arr)) {
+    arr = [];
+  }
+  return arr.sort((a, b) => {
     let aValue = 0;
     let bValue = 0;
     const aName = a.name && a.name.toLowerCase();

--- a/templates/testLayoutEmptyTemplate.json
+++ b/templates/testLayoutEmptyTemplate.json
@@ -213,5 +213,52 @@
     "emptyNotification": "No results found",
     "titleStyle": null,
     "autoPageBreak": true
+  },
+  {
+    "type": "chart",
+    "data": null,
+    "layout": {
+      "chartProperties": {
+        "barSize": 35,
+        "format": "DD MMM Y",
+        "isDatesChart": false,
+        "layout": "horizontal",
+        "showValues": true,
+        "timeFrame": "days",
+        "valuesFormat": "abbreviated"
+      },
+      "chartType": "column",
+      "columnPos": 8,
+      "dimensions": {
+        "height": 300,
+        "width": 332
+      },
+      "h": 3,
+      "i": "4bf15d80-0d8a-11ec-b214-d1631273aadb",
+      "legendStyle": {
+        "align": "right",
+        "hideLegend": false,
+        "iconType": "square",
+        "layout": "horizontal",
+        "verticalAlign": "top",
+        "wrapperStyle": {
+          "maxHeight": 96,
+          "top": 5,
+          "width": "100%"
+        }
+      },
+      "reflectDimensions": true,
+      "rowPos": 0,
+      "w": 4
+    },
+    "query": {
+      "type": "incident",
+      "groupBy": [
+        "severity",
+        "status"
+      ],
+      "filter": {}
+    },
+    "title": "NULL DATA"
   }
 ]

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -750,9 +750,9 @@ describe('Report Container', () => {
     const reportContainer = mount(toRender);
     const sectionChart = reportContainer.find(SectionChart);
     const emptyWidget = sectionChart.find('.widget-empty-state');
-    expect(emptyWidget).to.have.length(2);
+    expect(emptyWidget).to.have.length(3);
     const emptyWidgetIcon = sectionChart.find('.icon-status-noresults-24-r');
-    expect(emptyWidgetIcon).to.have.length(2);
+    expect(emptyWidgetIcon).to.have.length(3);
   });
 
   it('Generate test empty markdown template', () => {

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -760,10 +760,14 @@ describe('Report Container', () => {
     const toRender = <ReportContainer sections={prepareSections(testTemplate)} />;
     const reportContainer = mount(toRender);
     const sectionMark = reportContainer.find(SectionMarkdown);
-    const emptyWidget = sectionMark.find('.widget-empty-state');
+    let emptyWidget = sectionMark.find('.widget-empty-state');
     expect(emptyWidget).to.have.length(1);
     const emptyWidgetIcon = sectionMark.find('.icon-status-noresults-24-r');
     expect(emptyWidgetIcon).to.have.length(1);
+
+    const sectionChart = reportContainer.find(SectionChart);
+    emptyWidget = sectionChart.find('.widget-empty-state');
+    expect(emptyWidget).to.have.length(3);
   });
 
   it('Generate test non-empty markdown template', () => {


### PR DESCRIPTION
protect array functions like sort from non array values (null, undefined or objects) that were causing the client to fail before error boundaries