### PR TITLE
fix section item header text transform capitalized

### DIFF
--- a/src/components/Sections/ItemsSection.less
+++ b/src/components/Sections/ItemsSection.less
@@ -16,6 +16,10 @@
     height: auto;
     min-height: 50px;
 
+    .section-item-header {
+      text-transform: capitalize;
+    }
+
     &.card {
       .section-item-header {
         padding-bottom: 6px;


### PR DESCRIPTION
## Need
Capitalized item headers

## Before
![image](https://user-images.githubusercontent.com/89729679/147217717-3104d604-2c37-4040-9236-2205f0b4b443.png)

## After
![image](https://user-images.githubusercontent.com/89729679/147218002-ec4a2bea-469a-4392-9587-4d5e11fe2a55.png)

