### PR TITLE
fix disable header

### DIFF
--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -187,7 +187,7 @@ const MIN_TOP_MARGIN_PX = 40;
           printBackground: true,
           margin: {top: topMargin, bottom: BOTTOM_MARGIN},
           displayHeaderFooter: true,
-          headerTemplate: !disableHeaders ? headerTemplate : '',
+          headerTemplate: !disableHeaders ? headerTemplate : '<div/>',
           footerTemplate,
           landscape: orientation === PAGE_ORIENTATION.landscape
         });


### PR DESCRIPTION
## Status

- [x] Ready

## Related Issues

Fixes https://github.com/demisto/etc/issues/46284

## Description
Fix disable header - according to puppeteer docs the  `headerTemplate` option should be a valid `HTML markup` string.
Empty string fail in validation and causes the header to display default values like current date.

Relevant documentation -https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions

