### PR TITLE
fix zero value not been rendered in table

### DIFF
--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -83,10 +83,13 @@ const SectionTable = ({ columns, readableHeaders, data, classes, style, title, t
               {readyColumns.map((col, j) =>
                 (() => {
                   const key = col.key || col;
-                  const cell = row[key] || (readableHeaders && row[readableHeaders[key]]);
+                  let cell = row[key];
+                  if (cell === undefined || cell === null) {
+                    cell = readableHeaders && row[readableHeaders[key]];
+                  }
 
                   let cellToRender = '';
-                  if (cell) {
+                  if (cell || cell === 0) {
                     switch (cell.type) {
                       case TABLE_CELL_TYPE.image:
                         cellToRender = (

--- a/templates/testLayout.json
+++ b/templates/testLayout.json
@@ -892,6 +892,11 @@
         "aaa": "aaaa",
         "bbb": "bbb",
         "ccc": "ccc"
+      },
+      {
+        "aaa": 0,
+        "bbb": "",
+        "ccc": "ccc"
       }
     ],
     "layout": {

--- a/tests/containers/ReportContainer_spec.js
+++ b/tests/containers/ReportContainer_spec.js
@@ -739,6 +739,19 @@ describe('Report Container', () => {
     const sectionTable = reportContainer.find(SectionTable);
     const emptyWidget = sectionTable.find('.widget-empty-state');
     expect(emptyWidget).to.have.length(0);
+
+    const tableEl = sectionTable.at(1).find('table');
+    const tableHeader = tableEl.find('th');
+    expect(tableEl).to.have.length(1);
+    expect(tableHeader).to.have.length(2);
+    expect(tableHeader.at(0).text()).to.equal('aaa');
+    expect(tableHeader.at(1).text()).to.equal('bbb');
+    const cells = tableEl.find('td');
+    expect(cells).to.have.length(4);
+    expect(cells.at(0).text()).to.equal('aaaa');
+    expect(cells.at(1).text()).to.equal('bbb');
+    expect(cells.at(2).text()).to.equal('0');
+    expect(cells.at(3).text()).to.equal('');
   });
 
   it('Generate test empty generic template', () => {


### PR DESCRIPTION
make sure zero values given in tables as cell value would be rendered with our without given readable headers + added test

![image](https://user-images.githubusercontent.com/18641362/159960647-597999a6-45df-480d-ad27-833359ca6bbc.png)
