### PR TITLE
fix page break inside makrdown

### DIFF
--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -37,7 +37,6 @@
     margin-block-end: 1.1em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    page-break-inside: avoid;
 
     &:last-child {
       margin-bottom: 0 !important;

--- a/src/components/Sections/SectionMarkdown.less
+++ b/src/components/Sections/SectionMarkdown.less
@@ -13,7 +13,6 @@
 
   img {
     max-width: 100%;
-    page-break-inside: avoid;
   }
 
   .markdown {


### PR DESCRIPTION
Fixes CRTX-57370
https://jira-hq.paloaltonetworks.local/browse/CRTX-57370

revert page break inside markdowns 

Before fix 
<img width="575" alt="image" src="https://user-images.githubusercontent.com/61918543/175799544-ff321056-08f8-4c9e-9810-a3c74d26585d.png">

After fix - 
<img width="492" alt="image" src="https://user-images.githubusercontent.com/61918543/175799519-4e729b20-cdfd-4caa-b17a-d53731fd7960.png">

