### PR TITLE
CRTX-63401: Downloading a report with an empty 'General Purpose Section'

### DIFF
--- a/src/components/Sections/ItemsSection.js
+++ b/src/components/Sections/ItemsSection.js
@@ -149,7 +149,8 @@ class ItemsSection extends Component {
     return (
       <AutoSizer disableHeight>
         {({ width }) => {
-          const lastRowIndex = maxBy(items, item => item.index).index;
+          const lastRow = maxBy(items, item => item.index);
+          const lastRowIndex = lastRow ? lastRow.index : null;
           const allItemsAreDisplayedAsCards = every(items,
             item => ItemsSection.getItemDisplayType(item) === SECTION_ITEMS_DISPLAY_LAYOUTS.card
           );


### PR DESCRIPTION
Downloading a report with an empty 'General Purpose Section' displays an error in the report.

![Screen Shot 2022-10-18 at 17 39 39](https://user-images.githubusercontent.com/73780437/196462288-b7eb90f0-85bc-446d-8d56-ff0e400ab6a3.png)

[incidentDailyReportTempalte.pdf](https://github.com/demisto/sane-reports/files/9811530/incidentDailyReportTempalte.pdf)

Notes: can't use `lastRow?.index` because of it is not supported in the build proccess.