### PR TITLE
CRTX-64873: Panels are overlapping on each other

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -117,6 +117,12 @@ h1 {
         }
       }
 
+      &.section-itemsSection {
+        > div:first-child {
+          display: inline-block;
+        }
+      }
+
       .section-item-value {
         .section-markdown,
         .section-table {


### PR DESCRIPTION
This PR fixes overlapping issues with itemsSections and makes them breakable.

### Before:
[1-master.pdf](https://github.com/demisto/sane-reports/files/9860314/1-master.pdf)
[2-master.pdf](https://github.com/demisto/sane-reports/files/9860312/2-master3-master.pdf)
[3-master.pdf](https://github.com/demisto/sane-reports/files/9860514/3-master.pdf)

### After:
[1.pdf](https://github.com/demisto/sane-reports/files/9860595/1.pdf)
[2.pdf](https://github.com/demisto/sane-reports/files/9860606/2.pdf)
[3.pdf](https://github.com/demisto/sane-reports/files/9860569/3.pdf)

