### PR TITLE
CRTX-64873: Always display date in section if exists

### DIFF
--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -141,7 +141,7 @@ export function getSectionComponent(section, maxWidth) {
     case SECTION_TYPES.date:
       sectionToRender = (
         <SectionDate
-          date={section.layout.useCurrentTime ? moment() : section.data}
+          date={section.data || (section.layout.useCurrentTime ? moment() : undefined)}
           style={section.layout.style}
           format={section.layout.format}
         />


### PR DESCRIPTION
Related PR: https://github.com/demisto/sane-reports/pull/230.

The scenario that `useCurrentTime` exists with a `date` doesn't exist.
It is just in case.