### PR TITLE
CRTX-66801: Fix issues in section bar chart

### DIFF
--- a/src/components/Sections/SectionChart/SectionBarChart.js
+++ b/src/components/Sections/SectionChart/SectionBarChart.js
@@ -199,22 +199,28 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
     dataItems = dataItems.sort((a, b) => sortByField(['sum', 'name'], [false, true])(a, b));
   }
 
-  const isFull = !reflectDimensions;
   const barSize = chartProperties.barSize || WIDGET_DEFAULT_CONF.barSize;
+  const isLegend = legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend;
 
-  let minHeight = Math.min(BAR_CHART_FULL_ITEM_HEIGHT,
-    dataItems.length * (barSize + WIDGET_DEFAULT_CONF.barSizeMargin));
+  const isFull = !reflectDimensions;
+  if (isFull) {
+    let minHeight = BAR_CHART_FULL_ITEM_HEIGHT;
+    if (chartProperties.layout === CHART_LAYOUT_TYPE.horizontal) {
+      minHeight = Math.min(minHeight, dataItems.length * (barSize + WIDGET_DEFAULT_CONF.barSizeMargin));
+    } else if (isLegend) {
+      minHeight += dataItems.length * CHART_LEGEND_ITEM_HEIGHT;
+    }
 
-  if (chartProperties.layout === CHART_LAYOUT_TYPE.vertical) {
-    minHeight += (dataItems.length * CHART_LEGEND_ITEM_HEIGHT);
+    dimensions.height = Math.max(dimensions.height, minHeight);
   }
+
   return (
     <div className={mainClass} style={style}>
       <AutoSizer>
         {({ width, height }) => {
           const finalWidth = width || dimensions.width;
           const xAxisProps = isColumnChart ? createXAxisProps(data, 'name', finalWidth / 2) : {};
-          const finalHeight = Math.max(isFull ? dimensions.height : height || dimensions.height, minHeight);
+          const finalHeight = isFull ? dimensions.height : height || dimensions.height;
 
           return (
             <BarChart
@@ -265,7 +271,7 @@ const SectionBarChart = ({ data, style, dimensions, legend, chartProperties = {}
                 />}
               </XAxis>}
               <Tooltip />
-              {legendStyle && Object.keys(legendStyle).length > 0 && !legendStyle.hideLegend &&
+              {isLegend &&
                 <Legend
                   content={<ChartLegend
                     data={dataItems}


### PR DESCRIPTION
![Screen Shot 2022-11-17 at 17 37 36](https://user-images.githubusercontent.com/73780437/202490477-8dffcaef-e569-49b3-b967-fc977228d9b4.png)

The report (some of them with `force print full chart`): [report-Test2.txt](https://github.com/demisto/sane-reports/files/10033053/report-Test2.txt)

- when `reflectDimensions: true`  the widgets should look the same as the client. this is the default.
test report for this case: [incidentDailyReportTempalte-1.txt](https://github.com/demisto/sane-reports/files/10033027/incidentDailyReportTempalte-1.txt)

- when `reflectDimensions: false`  the widgets will take more space if needed to be fully visible.
test report for this case: [incidentDailyReportTempalte-2.txt](https://github.com/demisto/sane-reports/files/10033032/incidentDailyReportTempalte-2.txt)

In this PR:
- when `reflectDimensions: true`  the graph should fit the available space. taking more space than it had made the graphs to truncate in the middle
- improving the min-height calculation:
   - no need to take into account the legend if it doesn't exist
   - the calculation of the vertical graph doesn't need to take into account the number of the bars. 

Generating the reports with latest master:
- [incidentDailyReportTempalte-master-1.pdf](https://github.com/demisto/sane-reports/files/10033087/incidentDailyReportTempalte-master-1.pdf)
- [incidentDailyReportTempalte-master-2.pdf](https://github.com/demisto/sane-reports/files/10033098/incidentDailyReportTempalte-master-2.pdf)

Generating the reports with this branch:
- [incidentDailyReportTempalte-CRTX-66801-1.pdf](https://github.com/demisto/sane-reports/files/10033122/incidentDailyReportTempalte-CRTX-66801-1.pdf)
- [incidentDailyReportTempalte-CRTX-66801-2.pdf](https://github.com/demisto/sane-reports/files/10033128/incidentDailyReportTempalte-CRTX-66801-2.pdf)

![Screen Shot 2022-11-17 at 17 35 25](https://user-images.githubusercontent.com/73780437/202490883-7c38c5b4-3c16-4f2f-985d-f061408573c1.png)
![Screen Shot 2022-11-17 at 17 35 34](https://user-images.githubusercontent.com/73780437/202490892-d1635cbe-aaab-4eec-894e-0958be881c7c.png)
![Screen Shot 2022-11-17 at 17 35 43](https://user-images.githubusercontent.com/73780437/202490871-afeaba59-353e-4632-a8f2-1a02b770ecaa.png)
