### PR TITLE
CRTX-79881: Use none timeframe when all the name are unformmatable

### DIFF
--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -48,13 +48,15 @@ const createXAxisProps = (data, dataKey, width) => {
 };
 
 const getTimeFrame = (preparedData, chartProperties) => {
-  const allNamesAreUnformattable = preparedData.every((mainGroup) => {
-    const name = mainGroup.name;
-    return name && isNaN(name) && !moment(name).isValid();
-  });
+  if (chartProperties.timeFrame !== SUPPORTED_TIME_FRAMES.none) {
+    const allNamesAreUnformattable = preparedData.every((mainGroup) => {
+      const name = mainGroup.name;
+      return name && isNaN(name) && !moment(name).isValid();
+    });
 
-  if (allNamesAreUnformattable) {
-    return SUPPORTED_TIME_FRAMES.none;
+    if (allNamesAreUnformattable) {
+      return SUPPORTED_TIME_FRAMES.none;
+    }
   }
 
   return chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;

--- a/src/components/Sections/SectionChart/SectionLineChart.js
+++ b/src/components/Sections/SectionChart/SectionLineChart.js
@@ -47,6 +47,19 @@ const createXAxisProps = (data, dataKey, width) => {
   return props;
 };
 
+const getTimeFrame = (preparedData, chartProperties) => {
+  const allNamesAreUnformattable = preparedData.every((mainGroup) => {
+    const name = mainGroup.name;
+    return name && isNaN(name) && !moment(name).isValid();
+  });
+
+  if (allNamesAreUnformattable) {
+    return SUPPORTED_TIME_FRAMES.none;
+  }
+
+  return chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;
+};
+
 const SectionLineChart = ({ data, groupBy, style, dimensions, legend, chartProperties = {}, legendStyle = null,
   referenceLineX, referenceLineY, fromDate, toDate, reflectDimensions }) => {
   const { valuesFormat } = chartProperties;
@@ -59,7 +72,7 @@ const SectionLineChart = ({ data, groupBy, style, dimensions, legend, chartPrope
   };
 
   const finalToDate = toDate || moment().utc();
-  const timeFrame = chartProperties.timeFrame || SUPPORTED_TIME_FRAMES.days;
+  const timeFrame = getTimeFrame(preparedData, chartProperties);
   const lineTypes = {};
   let from = fromDate && moment(fromDate).utc();
   const timeFormat = chartProperties.format || QUERIES_TIME_FORMAT;


### PR DESCRIPTION
I generated the reported json from the issue: [incidentDailyReportTempalte.txt](https://github.com/demisto/sane-reports/files/11260877/incidentDailyReportTempalte.txt)

The generated report after these changes: [incidentDailyReportTempalte.pdf](https://github.com/demisto/sane-reports/files/11260882/incidentDailyReportTempalte.pdf)

When all the group names can't be formatted (null, number, valid string like '13/10/1992') we use the timeFrame 'none'.

This is how the report looks like without these changes / when we have any formattable name: [incidentDailyReportTempalte.pdf](https://github.com/demisto/sane-reports/files/11260931/incidentDailyReportTempalte.pdf)

