### PR TITLE
add server config support to force using server formatted time strings

### DIFF
--- a/index.template.html
+++ b/index.template.html
@@ -12,6 +12,7 @@
     var forceAutoHeightLayout = '{force-auto-height}';
     var markdownArtifactsServerAddress = '{md-server-address-to-replace}';
     var maxTableTextLength = '{max-table-text-length}';
+    var useServerFormattedDate = '{use-server-formatted-date}';
   </script>
   <body>
     <div id="app"></div>

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -73,7 +73,7 @@ const MIN_TOP_MARGIN_PX = 40;
   const forceAutoHeightLayout = process.argv[14] === true || process.argv[14] === "true";
   const markdownArtifactsServerAddress = process.argv[15] || '';
   const maxTableTextLength = process.argv[16] || 300;
-  const useServerFormattedDate = process.argv[17] || "false"
+  const useServerFormattedDate =  process.argv[17] === true || process.argv[17] === "true";
   let browser;
 
   if (process.env.NODE_ENV === 'test') {

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -73,13 +73,14 @@ const MIN_TOP_MARGIN_PX = 40;
   const forceAutoHeightLayout = process.argv[14] === true || process.argv[14] === "true";
   const markdownArtifactsServerAddress = process.argv[15] || '';
   const maxTableTextLength = process.argv[16] || 300;
+  const useServerFormattedDate = process.argv[17] || "false"
   let browser;
 
   if (process.env.NODE_ENV === 'test') {
     console.table ? console.table({
       dataFile, outputFile, distDir, orientation, resourceTimeout, reportType,
       headerLeftImage, headerRightImage, pageSize, disableHeaders, chromeExecution,
-      forceAutoHeightLayout, markdownArtifactsServerAddress
+      forceAutoHeightLayout, markdownArtifactsServerAddress, maxTableTextLength, useServerFormattedDate
     }) : console.log('args:', process.argv);
   }
 
@@ -123,7 +124,8 @@ const MIN_TOP_MARGIN_PX = 40;
             .replace('{report-dimensions}', JSON.stringify({ height: dimensions.height, width: dimensions.width }))
             .replace('{force-auto-height}', !!forceAutoHeightLayout)
             .replace('{md-server-address-to-replace}', markdownArtifactsServerAddress)
-            .replace('{max-table-text-length}', maxTableTextLength);
+            .replace('{max-table-text-length}', maxTableTextLength)
+            .replace('{use-server-formatted-date}', useServerFormattedDate);
     const loadedData = fs.readFileSync(dataFile).toString();
 
     // $ is a special character in string replace, see here: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter

--- a/src/components/Sections/SectionDate.js
+++ b/src/components/Sections/SectionDate.js
@@ -2,7 +2,12 @@ import './SectionDate.less';
 import React from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment-timezone';
-import { DEFAULT_DATE_TIME_FORMAT, PARSING_STRING_WITH_TIME_ZONE } from '../../constants/Constants';
+import {
+  DEFAULT_DATE_TIME_FORMAT,
+  PARSING_STRING_WITH_TIME_ZONE,
+  setUseServerFormattedDate,
+  shouldUseServerFormattedDate
+} from '../../constants/Constants';
 
 function isInvalidDate(date) {
   return !date || (date.startsWith && date.startsWith('0001-01-01 00:00:00'));
@@ -30,12 +35,19 @@ export function dateToMoment(date) {
 
 const SectionDate = ({ date, style, format, isPrefixRequired = true }) => {
   const dateTime = dateToMoment(date);
+  let value;
+  setUseServerFormattedDate(true);
+  if (shouldUseServerFormattedDate() && moment(date).isValid()) {
+    value = date;
+  } else {
+    value = moment.isMoment(dateTime) ? dateTime.tz(moment.tz.guess())
+      .format(format || DEFAULT_DATE_TIME_FORMAT) : dateTime;
+  }
   return (
     <div className="section-date" style={style}>
       {isPrefixRequired && <span className="section-date-key">Date:</span>}
       <span className="section-date-value">
-        {moment.isMoment(dateTime) ? dateTime.tz(moment.tz.guess())
-          .format(format || DEFAULT_DATE_TIME_FORMAT) : dateTime}
+        {value}
       </span>
     </div>);
 };

--- a/src/components/Sections/SectionDate.js
+++ b/src/components/Sections/SectionDate.js
@@ -5,7 +5,6 @@ import moment from 'moment-timezone';
 import {
   DEFAULT_DATE_TIME_FORMAT,
   PARSING_STRING_WITH_TIME_ZONE,
-  setUseServerFormattedDate,
   shouldUseServerFormattedDate
 } from '../../constants/Constants';
 
@@ -36,8 +35,7 @@ export function dateToMoment(date) {
 const SectionDate = ({ date, style, format, isPrefixRequired = true }) => {
   const dateTime = dateToMoment(date);
   let value;
-  setUseServerFormattedDate(true);
-  if (shouldUseServerFormattedDate() && moment(date).isValid()) {
+  if (shouldUseServerFormattedDate() && !isInvalidDate(date) && moment(date).isValid()) {
     value = date;
   } else {
     value = moment.isMoment(dateTime) ? dateTime.tz(moment.tz.guess())

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -60,6 +60,15 @@ export function setMarkdownImageServer(mdServerAddress) {
   markdownImageServer = mdServerAddress;
 }
 
+let useServerFormattedDate = false;
+export function setUseServerFormattedDate(useServerDate) {
+  useServerFormattedDate = useServerDate;
+}
+
+export function shouldUseServerFormattedDate() {
+  return useServerFormattedDate;
+}
+
 export const CHART_LAYOUT_TYPE = {
   horizontal: 'horizontal',
   vertical: 'vertical'

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,8 @@ import {
   REPORT_TYPES,
   PIXEL_SIZE,
   setDefaultMaxLength,
-  setMarkdownImageServer
+  setMarkdownImageServer,
+  setUseServerFormattedDate
 } from './constants/Constants';
 import { prepareSections, getReportType } from './utils/reports';
 import { generateOfficeReport } from './office/OfficeReport';
@@ -30,6 +31,7 @@ const sections = prepareSections(data, type);
 
 setMarkdownImageServer(markdownArtifactsServerAddress);
 setDefaultMaxLength(maxTableTextLength);
+setUseServerFormattedDate(useServerFormattedDate);
 
 let isLayout = false;
 if (sections) {


### PR DESCRIPTION
server already formatting the section date data.
currently, sane is formatting the data using a hard coded format and its own TZ (running machine)
