### PR TITLE
sectionDate validate isMoment before enforceing server formatting

### DIFF
--- a/src/components/Sections/SectionDate.js
+++ b/src/components/Sections/SectionDate.js
@@ -35,7 +35,7 @@ export function dateToMoment(date) {
 const SectionDate = ({ date, style, format, isPrefixRequired = true }) => {
   const dateTime = dateToMoment(date);
   let value;
-  if (shouldUseServerFormattedDate() && !isInvalidDate(date)) {
+  if (shouldUseServerFormattedDate() && !isInvalidDate(date) && !moment.isMoment(date)) {
     value = date;
   } else {
     value = moment.isMoment(dateTime) ? dateTime.tz(moment.tz.guess())


### PR DESCRIPTION
when no "data" is provided in the section and "section.layout.useCurrentTime" set to "true", the sane pass the current time as a "moment" object.

in this case we need to fall back into the formatting state and not use the "server formatted time" as it is not formatted by the server 