### PR TITLE
Reflect dimentions in table section

### DIFF
--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -23,7 +23,7 @@ function getExtraPropsForColumn(key, columnsMetaDataMap, headerStyle) {
 }
 
 const SectionTable = ({ columns, readableHeaders, data, extraData, classes, style, title, titleStyle, emptyString,
-  maxColumns, forceRangeMessage, headerStyle }) => {
+  maxColumns, forceRangeMessage, reflectDimensions, headerStyle }) => {
   let tableData = data || [];
 
   if (isString(data)) {
@@ -112,7 +112,7 @@ const SectionTable = ({ columns, readableHeaders, data, extraData, classes, styl
                         break;
                       }
                       default: {
-                        cellToRender = truncate(cell, { length: defaultMaxLength });
+                        cellToRender = reflectDimensions ? cell : truncate(cell, { length: defaultMaxLength });
                       }
                     }
                   }
@@ -160,7 +160,7 @@ const SectionTable = ({ columns, readableHeaders, data, extraData, classes, styl
               <td style={{ background: 'rgb(249, 250, 251)', width: '20%', whiteSpace: 'nowrap' }}>
                 {key}
               </td>
-              <td>{truncate(val, { length: defaultMaxLength })}</td>
+              <td>{reflectDimensions ? val : truncate(val, { length: defaultMaxLength })}</td>
             </tr>
           ))}
         </tbody>
@@ -193,6 +193,7 @@ SectionTable.propTypes = {
   titleStyle: PropTypes.object,
   emptyString: PropTypes.string,
   forceRangeMessage: PropTypes.string,
+  reflectDimensions: PropTypes.bool,
   headerStyle: PropTypes.object
 };
 

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -206,6 +206,7 @@ export function getSectionComponent(section, maxWidth) {
           titleStyle={section.titleStyle}
           title={section.title}
           maxColumns={section.layout.maxColumns || (maxWidth ? maxWidth / 100 : 0)}
+          reflectDimensions={section.layout.reflectDimensions}
           emptyString={section.emptyNotification || getDefaultEmptyNotification()}
           forceRangeMessage={section.layout.forceRangeMessage}
           headerStyle={section.layout.headerStyle}


### PR DESCRIPTION
#### Description

Cells inside tables is getting truncated even thought `reflectDimensions` is set to true.

![Screenshot 2023-09-27 at 12 31 54](https://github.com/demisto/sane-reports/assets/73780437/7b5aae3f-62cf-45fb-8284-7ebcdf51d899)

#### Example JSON

```
[
  {
    "type": "table",
    "data": {
      "data": [
        {
          "Critical Updates": "SIR0041393 - SOC was notified during the Red Team exercise, a potential compromise of Alstom application website 'solochain'. As per investigation, the website” supplychain.alstom.com” resolving to IP 81.31.28.99 and identified with multiple vulnerabilities. Remediation action is underway with application and network teams.",
          "Service": "SOC"
        },
        {
          "Critical Updates": "Logging Fluctuations in Sentinel: We have been seeing some fluctuations in the logging to Sentinel because of which multiple critical network assets have been found to be in ‘Unhealthy state’ at random times. MS Team has already been involved to identify and fix the issue. Project team increased incoming rate limit on the forwarder but post increment also couple of log sources went down. The same has been highlighted to MS.\n\nInitial observation from MS:\n1.\tThe log message indicates that the Linux server is experiencing a high volume of incoming TCP SYN (Synchronize) packets on port 514\n-\t\"\"Possible SYN flooding\"\" messages found on the server logs: 2023-09-04T09:13:50.659182+00:00 srsdc307775l037 kernel: TCP: request_sock_TCP: Possible SYN flooding on port 514. Sending cookies.  Check SNMP counter\n2.\tEnabled sysstat : to collect diagnostics logs on srsdc307775l037\n-\tWill connect again tomorrow to analyze the logs and adjust/fine tune the settings or configurations\"",
          "Service": "Azure forwarder/Sentinel"
        },
        {
          "Critical Updates": "Monthly report finalization has completed.",
          "Service": "VM"
        },
        {
          "Critical Updates": "DLP Policy: Alert is triggering, working on fine tune of the policy with MS.",
          "Service": "CASB"
        },
        {
          "Critical Updates": "SOC received SIR0041223- email fraud on Greek customer received original email conversation from Roberta of Alstom and looking for the original email conversation from the customer side. Scheduling a call with the Greek customer.",
          "Service": "Email Security"
        },
        {
          "Critical Updates": "NIL",
          "Service": "Cybel Angel"
        }
      ],
      "total": 5
    },
    "layout": {
      "classes": "striped stackable small compact",
      "columnPos": 0,
      "forceRangeMessage": "",
      "h": 5,
      "i": "6cd3b550-2261-11ee-8f99-9563f6307729",
      "readableHeaders": {
        "Critical Updates": "Critical Updates",
        "Service": "Service"
      },
      "reflectDimensions": true,
      "rowPos": 12,
      "tableColumns": [
        "Service",
        "Critical Updates"
      ],
      "tableColumnsMetaData": [
        {
          "displayed": true,
          "isDefault": true,
          "key": "Service",
          "width": 193
        },
        {
          "displayed": true,
          "isDefault": true,
          "key": "Critical Updates",
          "width": 1475
        }
      ],
      "w": 12
    },
    "query": {
      "type": "scripts",
      "filter": {
        "query": "Daily_Operational_Dashboard_Critical_Updates",
        "period": {
          "by": "",
          "byFrom": "days",
          "byTo": "",
          "field": "",
          "fromValue": 7,
          "toValue": null
        },
        "fromDate": "0001-01-01T00:00:00Z",
        "toDate": "0001-01-01T00:00:00Z"
      }
    },
    "automation": {
      "name": "",
      "id": "",
      "args": null,
      "noEvent": false
    },
    "fromDate": "2023-08-31T16:45:35+05:30",
    "title": "Daily Operational Critical Updates",
    "emptyNotification": "No results found",
    "titleStyle": null,
    "autoPageBreak": true
  }
]
```

#### Before
[before.pdf](https://github.com/demisto/sane-reports/files/12737040/before.pdf)

#### After
[after.pdf](https://github.com/demisto/sane-reports/files/12737047/after.pdf)
