### PR TITLE
CRTX-94501: Dockerfiles - CI fails when trying to update sane pdf report docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10.22.1-browsers
+      - image: circleci/node:10.24.1-browsers
     resource_class: large
     working_directory: ~/sane-reports
     steps:


### PR DESCRIPTION
#### Description

After talking with Lior Zadka it was suggested that upgrading the node version to 10.24.1 could fix the issue.

We already support this version (see Readme.md): https://github.com/demisto/sane-reports/.
