### PR TITLE
CRTX-96742: Broken tables in the PDF report Investigation summary

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -57,6 +57,26 @@ h1 {
     }
   }
 
+  .section-table, .section-markdown {
+    table {
+      break-inside: auto;
+    }
+
+    tr {
+      break-inside: avoid;
+      break-after: auto;
+    }
+
+    thead {
+      display: table-header-group;
+      break-inside: avoid;
+    }
+
+    tfoot {
+      display: table-header-group;
+    }
+  }
+
   .report-section {
     display: table-cell;
 
@@ -148,27 +168,6 @@ h1 {
 
       &.slim {
         height: auto !important;
-      }
-
-      &.section-table, &.section-markdown {
-
-        table {
-          break-inside: auto;
-        }
-
-        tr {
-          break-inside: avoid;
-          break-after: auto;
-        }
-
-        thead {
-          display: table-header-group;
-          break-inside: avoid;
-        }
-
-        tfoot {
-          display: table-header-group;
-        }
       }
 
       .section-title {


### PR DESCRIPTION
#### Description

There is an existing fix for this issue when it appears under `react-grid-layout`. 
![Screenshot 2023-11-14 at 15 49 11](https://github.com/demisto/sane-reports/assets/73780437/17cd7072-95b1-4b41-9a4b-79c5906ee642)

This PR makes it work the same in `reports-section`.
![Screenshot 2023-11-14 at 15 52 57](https://github.com/demisto/sane-reports/assets/73780437/7fa50255-4b84-4169-aac2-68a4eebaab23)

Tested on these examples to make sure this PR doesn't break anything:
- [incident_info.json](https://github.com/demisto/sane-reports/files/13349729/incident_info.json) - incident info tab with a markdown of a table and a grid field
- [investigation_summary.json](https://github.com/demisto/sane-reports/files/13349734/investigation_summary.json) - investigation summary tab

#### Snapshots
[incidentDailyReportTempalte.json](https://github.com/demisto/sane-reports/files/13403013/incidentDailyReportTempalte.json)
[before.pdf](https://github.com/demisto/sane-reports/files/13403014/before.pdf)
[after.pdf](https://github.com/demisto/sane-reports/files/13403015/after.pdf)

[incidentDailyReportTempalte.json](https://github.com/demisto/sane-reports/files/13402968/incidentDailyReportTempalte.json)
[before.pdf](https://github.com/demisto/sane-reports/files/13402970/before.pdf)
[after.pdf](https://github.com/demisto/sane-reports/files/13402971/after.pdf)





