### PR TITLE
CRTX-97293: Handle images that has /xsoar prefix

### DIFF
--- a/src/components/Sections/SectionMarkdown.js
+++ b/src/components/Sections/SectionMarkdown.js
@@ -8,7 +8,6 @@ import isString from 'lodash/isString';
 import { uniqueId } from 'lodash';
 import {
   getMarkdownImageServer,
-  MARKDOWN_IMAGES_ACC_PATH,
   MARKDOWN_IMAGES_PATH,
   PAGE_BREAK_KEY
 } from '../../constants/Constants';
@@ -83,7 +82,7 @@ export default class SectionMarkdown extends Component {
       }
       case 'img': {
         const srcArr = props.src.split('=size=');
-        if (srcArr[0].startsWith(MARKDOWN_IMAGES_PATH) || MARKDOWN_IMAGES_ACC_PATH.test(srcArr[0])) {
+        if (MARKDOWN_IMAGES_PATH.test(srcArr[0])) {
           props.src = `${getMarkdownImageServer()}${srcArr[0]}`;
         } else {
           props.src = srcArr[0];

--- a/src/constants/Constants.js
+++ b/src/constants/Constants.js
@@ -228,8 +228,7 @@ export const DATA_TYPES = {
   incident: 'incident'
 };
 
-export const MARKDOWN_IMAGES_PATH = '/markdown/image';
-export const MARKDOWN_IMAGES_ACC_PATH = /^\/acc_.*\/markdown\/image/;
+export const MARKDOWN_IMAGES_PATH = /^(\/xsoar)?(\/acc_.*)?\/markdown\/image/;
 
 export const PARSING_STRING_WITH_TIME_ZONE = 'YYYY-MM-DD HH:mm:ss.SSSSSS Z';
 export const DEFAULT_DATE_TIME_FORMAT = 'MMMM Do YYYY, h:mm a z';


### PR DESCRIPTION
#### Related PRS
https://github.com/demisto/content/pull/30744/files

#### Description
We added a server url to the image src when the images paths that started with `/xsoar/image` or with `acc_{name}/markdown/image`. 

In `XSOAR-NG` it works different because the path starts with `/xsoar`.

This PR handles images that the path starts also with `/xsoar`.:

![Screenshot 2023-11-15 at 14 32 42](https://github.com/demisto/sane-reports/assets/73780437/93a3f982-1557-4831-a1e8-8f987464313f)
