### PR TITLE
XSUP-29808: The force print full chart function is not working

### DIFF
--- a/src/components/Sections/SectionTable.js
+++ b/src/components/Sections/SectionTable.js
@@ -82,7 +82,7 @@ const SectionTable = ({ columns, columnsMetaData, readableHeaders, data, extraDa
           <tr>
             {readyColumns.map((col) => {
               const key = col.key || col;
-              const extraProps = getExtraPropsForColumn(key, columnsMetaDataMap, headerStyle);
+              const extraProps = reflectDimensions ? getExtraPropsForColumn(key, columnsMetaDataMap, headerStyle) : {};
 
               return (
                 <th key={key} {...extraProps}>


### PR DESCRIPTION
#### Description

In https://github.com/demisto/sane-reports/pull/256 we fixed a bug that we didn't used the original column width. 
The fix was made regardless of `force print full`.

This PR shows all the columns and ignores the columns width if `force print full` is on.

#### Snapshots

[force_print_on.json](https://github.com/demisto/sane-reports/files/13376543/force_print_on.json)
[force_print_on_before.pdf](https://github.com/demisto/sane-reports/files/13376542/force_print_on_before.pdf)
[force_print_on_after.pdf](https://github.com/demisto/sane-reports/files/13376544/force_print_on.pdf)

[force_print_off.json](https://github.com/demisto/sane-reports/files/13376546/force_print_off.json)
[force_print_off_before.pdf](https://github.com/demisto/sane-reports/files/13376545/force_print_off_before.pdf)
[force_print_off_after.pdf](https://github.com/demisto/sane-reports/files/13376547/force_print_off.pdf)
