### PR TITLE
CRTX-96742: Don't break certain global sections inside

### DIFF
--- a/src/components/Layouts/ReportLayout.less
+++ b/src/components/Layouts/ReportLayout.less
@@ -31,6 +31,11 @@ h1 {
     flex: 1;
     flex-direction: row;
 
+    &.no-break-inside {
+      break-inside: avoid;
+      break-after: auto;
+    }
+
     .subsection-wrapper {
       flex: 1;
       width: 100%;

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -252,8 +252,10 @@ export function getSectionComponent(section, maxWidth) {
           <>
             {compact(Object.entries(groupBy(section.data || [], s => s.layout.rowPos))
               .map(([rowNum, subSections]) => {
-                const noBreakInside =
-                  subSections.every(subSection => [SECTION_TYPES.text, SECTION_TYPES.date].includes(subSection.type));
+                const noBreakInside = subSections.length === 3 &&
+                  subSections[0].type === SECTION_TYPES.text &&
+                  subSections[1].type === SECTION_TYPES.date &&
+                  subSections[2].type === SECTION_TYPES.text;
 
                 return (
                   <div

--- a/src/utils/layout.js
+++ b/src/utils/layout.js
@@ -1,3 +1,4 @@
+import classNames from 'classnames';
 import { PAGE_BREAK_KEY, SECTION_TYPES } from '../constants/Constants';
 import {
   ItemsSection,
@@ -29,7 +30,7 @@ function getDefaultEmptyNotification() {
 
 function isPageBreakSection(section) {
   return !!get(section, 'layout.style.pageBreakBefore', false) || (section.type === SECTION_TYPES.markdown &&
-      section.data && ((isString(section.data) ? section.data : section.data.text) || '').includes(PAGE_BREAK_KEY));
+    section.data && ((isString(section.data) ? section.data : section.data.text) || '').includes(PAGE_BREAK_KEY));
 }
 
 export function getSectionComponent(section, maxWidth) {
@@ -179,7 +180,7 @@ export function getSectionComponent(section, maxWidth) {
           referenceLineX={section.layout.referenceLineX}
           referenceLineY={section.layout.referenceLineY}
           stacked={get(section, 'query.groupBy.length', 0) > 1 ||
-          (Array.isArray(section.data) && section.data.some(group => get(group, 'groups.length') > 0))}
+            (Array.isArray(section.data) && section.data.some(group => get(group, 'groups.length') > 0))}
           fromDate={section.fromDate}
           toDate={section.toDate}
           reflectDimensions={section.layout.reflectDimensions}
@@ -249,20 +250,27 @@ export function getSectionComponent(section, maxWidth) {
           {section.title && <div className="section-title" style={section.titleStyle}>{section.title}</div>}
           {section.description && <div className="section-description">{section.description}</div>}
           <>
-            {compact(Object.entries(groupBy(section.data || [], s => s.layout.rowPos)).map(([rowNum, subSections]) => {
-              return (
-                <div className="global-section-row" key={`${section.i}-${rowNum}`}>
-                  {(subSections || []).map((subSection, i) => {
-                    return (
-                      <div key={`${section.i}-${rowNum}-subsection-${i}`} className="subsection-wrapper">
-                        {getSectionComponent(subSection)}
-                      </div>
-                    );
-                  })}
-                </div>
-              );
-            }))}
-            { isEmpty(section.data) &&
+            {compact(Object.entries(groupBy(section.data || [], s => s.layout.rowPos))
+              .map(([rowNum, subSections]) => {
+                const noBreakInside =
+                  subSections.every(subSection => [SECTION_TYPES.text, SECTION_TYPES.date].includes(subSection.type));
+
+                return (
+                  <div
+                    className={classNames('global-section-row', { 'no-break-inside': noBreakInside })}
+                    key={`${section.i}-${rowNum}`}
+                  >
+                    {(subSections || []).map((subSection, i) => {
+                      return (
+                        <div key={`${section.i}-${rowNum}-subsection-${i}`} className="subsection-wrapper">
+                          {getSectionComponent(subSection)}
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              }))}
+            {isEmpty(section.data) &&
               <WidgetEmptyState emptyString={section.emptyNotification || getDefaultEmptyNotification()} />
             }
           </>


### PR DESCRIPTION
#### Description

We want to avoid splitting these sections:

![Screenshot 2023-12-04 at 15 02 33](https://github.com/demisto/sane-reports/assets/73780437/1db6dede-c975-4a27-9ff9-61e036c0e152)

#### Generated Reports

[incidentDailyReportTempalte.json](https://github.com/demisto/sane-reports/files/13546201/incidentDailyReportTempalte.json)
[before.pdf](https://github.com/demisto/sane-reports/files/13546200/before.pdf)
[after.pdf](https://github.com/demisto/sane-reports/files/13546199/after.pdf)

#### Validated that it works the same

[incidentDailyReportTempalte.json](https://github.com/demisto/sane-reports/files/13546224/incidentDailyReportTempalte.json)
[before.pdf](https://github.com/demisto/sane-reports/files/13546222/before.pdf)
[after.pdf](https://github.com/demisto/sane-reports/files/13546221/after.pdf)


