### PR TITLE
CRTX-99841: PieChart | Use colors from the template

### DIFF
--- a/src/components/Sections/SectionChart/SectionPieChart.js
+++ b/src/components/Sections/SectionChart/SectionPieChart.js
@@ -57,7 +57,7 @@ const SectionPieChart = ({ data, style, dimensions, legend, chartProperties = {}
   }
   Object.keys(dataMap).forEach((key) => {
     const graphItem = dataMap[key];
-    graphItem.fill = getGraphColorByName(graphItem.name, existingColors);
+    graphItem.fill = graphItem.fill || graphItem.color || getGraphColorByName(graphItem.name, existingColors);
     existingColors[graphItem.fill] = true;
     return preparedData.push(graphItem);
   });


### PR DESCRIPTION
#### Description

When we have a fill/color in an item we should take it from there.

How we did it in other places:

![Screenshot 2024-01-08 at 13 27 17](https://github.com/demisto/sane-reports/assets/73780437/981d8c8f-402f-438c-a876-0bea436c7c96)

---- 

#### Generated JSON
Validating with items with colors.

JSON: [CRTX-99841.json](https://github.com/demisto/sane-reports/files/13859324/CRTX-99841.json)

#### Before
[CRTX-99841_before.pdf](https://github.com/demisto/sane-reports/files/13859326/CRTX-99841_before.pdf)

#### After
[CRTX-99841_after.pdf](https://github.com/demisto/sane-reports/files/13859329/CRTX-99841_after.pdf)

----
#### Generated JSON
Validating with fill, color and empty use-cases.

JSON: [CRTX-99841-2.json](https://github.com/demisto/sane-reports/files/13859424/CRTX-99841-2.json)

#### Before
[CRTX-99841-2-before.pdf](https://github.com/demisto/sane-reports/files/13859450/CRTX-99841-2-before.pdf)

#### After
[CRTX-99841-2-after.pdf](https://github.com/demisto/sane-reports/files/13859427/CRTX-99841-2-after.pdf)
