### PR TITLE
XSUP-34767 - add utf8bom to csv header when needed

### DIFF
--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -201,7 +201,7 @@ const MIN_TOP_MARGIN_PX = 40;
         const csvData = await page.evaluate(evalsFunctions.getCSVData);
         if (csvData === '' || csvData) {
           fs.writeFileSync(outputFinal, csvData, { 'flag': 'w' });
-          fs.appendFileSync(outputFinal, "", "utf8")
+          fs.appendFileSync(outputFinal, "tutu", "utf8")
           console.log("CSV report was generated successfully.");
         } else {
           console.log("Failed to generate CSV report.");

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -74,6 +74,7 @@ const MIN_TOP_MARGIN_PX = 40;
   const markdownArtifactsServerAddress = process.argv[15] || '';
   const maxTableTextLength = process.argv[16] || 300;
   const useServerFormattedDate =  process.argv[17] === true || process.argv[17] === "true";
+  const addUTF8Bom =  process.argv[18] === true || process.argv[18] === "true";
   let browser;
 
   if (process.env.NODE_ENV === 'test') {
@@ -199,6 +200,9 @@ const MIN_TOP_MARGIN_PX = 40;
         const csvData = await page.evaluate(evalsFunctions.getCSVData);
         if (csvData === '' || csvData) {
           fs.writeFileSync(outputFinal, csvData, { 'flag': 'w' });
+          if (addUTF8Bom) {
+            fs.appendFileSync(outputFinal, "", "utf-8")
+          }
           console.log("CSV report was generated successfully.");
         } else {
           console.log("Failed to generate CSV report.");

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -6,6 +6,7 @@ const chromePath = require('@moonandyou/chrome-path');
 const fs = require('fs');
 const path = require('path');
 const { cloneDeep } = require('lodash')
+const buffer = require("buffer");
 
 const mmPixelSize = 3.779527559055;
 
@@ -200,7 +201,7 @@ const MIN_TOP_MARGIN_PX = 40;
         const csvData = await page.evaluate(evalsFunctions.getCSVData);
         if (csvData === '' || csvData) {
           fs.writeFileSync(outputFinal, csvData, { 'flag': 'w' });
-          fs.appendFileSync(outputFinal, "", "utf-8")
+          fs.appendFileSync(outputFinal, "", "utf8")
           console.log("CSV report was generated successfully.");
         } else {
           console.log("Failed to generate CSV report.");

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -200,9 +200,7 @@ const MIN_TOP_MARGIN_PX = 40;
         const csvData = await page.evaluate(evalsFunctions.getCSVData);
         if (csvData === '' || csvData) {
           fs.writeFileSync(outputFinal, csvData, { 'flag': 'w' });
-          if (addUTF8Bom) {
-            fs.appendFileSync(outputFinal, "", "utf-8")
-          }
+          fs.appendFileSync(outputFinal, "", "utf-8")
           console.log("CSV report was generated successfully.");
         } else {
           console.log("Failed to generate CSV report.");

--- a/reportService/reportsServer.js
+++ b/reportService/reportsServer.js
@@ -6,13 +6,14 @@ const chromePath = require('@moonandyou/chrome-path');
 const fs = require('fs');
 const path = require('path');
 const { cloneDeep } = require('lodash')
-const buffer = require("buffer");
 
 const mmPixelSize = 3.779527559055;
 
 const PAGE_MARGIN = 61;
 const BOTTOM_MARGIN = 40;
 const MIN_TOP_MARGIN_PX = 40;
+
+const utf8BOM = '\ufeff';
 
 (async() => {
   const paths = await chromePath();
@@ -198,10 +199,12 @@ const MIN_TOP_MARGIN_PX = 40;
         break;
       }
       case 'csv': {
-        const csvData = await page.evaluate(evalsFunctions.getCSVData);
+        let csvData = await page.evaluate(evalsFunctions.getCSVData);
         if (csvData === '' || csvData) {
+          if (addUTF8Bom) {
+            csvData = utf8BOM + csvData
+          }
           fs.writeFileSync(outputFinal, csvData, { 'flag': 'w' });
-          fs.appendFileSync(outputFinal, "tutu", "utf8")
           console.log("CSV report was generated successfully.");
         } else {
           console.log("Failed to generate CSV report.");


### PR DESCRIPTION
add utf8bom to csv header when needed to support hebrew in MS Excel.
it will only be enforced when "addUtf8Bom" arg is passed by the sane script (which is affected by server config)

before:
![image](https://github.com/demisto/sane-reports/assets/47333909/ce11ba12-513a-4f53-a84e-99b8c74d7eb0)


after:
![image](https://github.com/demisto/sane-reports/assets/47333909/575d16bc-2770-4018-9141-9e493cdaab60)
