### PR TITLE
CRTX-90233: CSV | Support rendering SLA field in timer cell

### DIFF
--- a/src/components/Cells/TimerCell/TimeTicker.js
+++ b/src/components/Cells/TimerCell/TimeTicker.js
@@ -108,6 +108,7 @@ export class TimeTicker extends Component {
   }
 
   render() {
+    const { duration, startDate, dueDate, timePeriod, riskThreshold } = this.props;
     const {
       doesHaveDueDate,
       slaPart,
@@ -116,7 +117,7 @@ export class TimeTicker extends Component {
       dueDateStr,
       slaMessage,
       slaStatusObject
-    } = TimeTicker.getTimePickerData(this.props);
+    } = TimeTicker.getTimePickerData({ duration, startDate, dueDate, timePeriod, riskThreshold });
 
     const wrapperClass = classNames('sla-status', slaStatusObject);
     const iconClass = classNames('demisto-icon', {

--- a/src/components/Cells/TimerCell/TimeTicker.js
+++ b/src/components/Cells/TimerCell/TimeTicker.js
@@ -21,7 +21,7 @@ export class TimeTicker extends Component {
     timePeriod: TIME_PERIODS.MILISECONDS
   };
 
-  getSlaStatus = (slaStatusObject) => {
+  static getSlaStatus = (slaStatusObject) => {
     const slaStatus = Object.keys(slaStatusObject)[0];
     switch (slaStatus) {
       case 'late':
@@ -35,20 +35,26 @@ export class TimeTicker extends Component {
     }
   }
 
-  render() {
-    const { duration, startDate, dueDate, timePeriod, riskThreshold } = this.props;
+  static getTimePickerData(timerProps) {
+    const { duration, startDate, dueDate, timePeriod, riskThreshold } = timerProps;
     let finalDuration = duration;
     let durationType = timePeriod;
-    const finalDueDate = dueDate && !isZeroDateTime(dueDate) ? moment(dueDate).local() : undefined;
-    const finalStartDate = startDate && !isZeroDateTime(startDate) ? moment(startDate).local() : undefined;
+    const finalDueDate = dueDate && !isZeroDateTime(dueDate) ? moment(dueDate)
+      .local() : undefined;
+    const finalStartDate = startDate && !isZeroDateTime(startDate) ? moment(startDate)
+      .local() : undefined;
     const doesHaveDueDate = !!finalDueDate;
     const isDurationSet = !!finalDuration || finalDuration === 0;
     if (!isDurationSet) {
       durationType = TIME_PERIODS.MINUTES;
       if (finalDueDate) {
-        finalDuration = moment(finalDueDate).diff(moment().local(), durationType);
+        finalDuration = moment(finalDueDate)
+          .diff(moment()
+            .local(), durationType);
       } else {
-        finalDuration = moment().local().diff(finalStartDate, durationType);
+        finalDuration = moment()
+          .local()
+          .diff(finalStartDate, durationType);
       }
     }
 
@@ -56,21 +62,28 @@ export class TimeTicker extends Component {
     let elapsed = '';
     let isNegative = false;
     let isRisk = false;
+
     if (finalDueDate && finalStartDate) {
-      const sla = moment(finalDueDate).diff(finalStartDate, TIME_PERIODS.MINUTES);
+      const sla = moment(finalDueDate)
+        .diff(finalStartDate, TIME_PERIODS.MINUTES);
       slaPart = getDurationString(sla, TIME_PERIODS.MINUTES);
     }
+    slaPart = `SLA: ${slaPart}`;
+
     if (finalDuration < 0) {
       isNegative = true;
       finalDuration *= -1;
       if (finalDueDate) {
         if (isDurationSet) {
-          const diff = moment(finalDueDate).diff(moment(startDate), durationType);
+          const diff = moment(finalDueDate)
+            .diff(moment(startDate), durationType);
           elapsed = getDurationString(diff + finalDuration, durationType);
         } else {
-          const elapsedMinutes = moment().diff(finalStartDate, TIME_PERIODS.MINUTES);
+          const elapsedMinutes = moment()
+            .diff(finalStartDate, TIME_PERIODS.MINUTES);
           elapsed = getDurationString(elapsedMinutes, TIME_PERIODS.MINUTES);
         }
+        elapsed = `Total Elapsed: ${elapsed}`;
       }
     } else if (finalDueDate && riskThreshold > 0) {
       const durationInMinutes = durationType === TIME_PERIODS.MINUTES ? finalDuration : finalDuration / 60;
@@ -88,12 +101,29 @@ export class TimeTicker extends Component {
       },
       v => v
     );
+
+    const slaMessage = `${TimeTicker.getSlaStatus(slaStatusObject)}: `;
+
+    return { doesHaveDueDate, slaPart, elapsed, timeToRender, dueDateStr, slaMessage, slaStatusObject };
+  }
+
+  render() {
+    const {
+      doesHaveDueDate,
+      slaPart,
+      elapsed,
+      timeToRender,
+      dueDateStr,
+      slaMessage,
+      slaStatusObject
+    } = TimeTicker.getTimePickerData(this.props);
+
     const wrapperClass = classNames('sla-status', slaStatusObject);
     const iconClass = classNames('demisto-icon', {
       'icon-field-timer-24-r': !doesHaveDueDate,
       'icon-field-sla-24-r': doesHaveDueDate
     });
-    const slaMessage = `${this.getSlaStatus(slaStatusObject)}: `;
+
     return (
       <div className="time-ticker">
         <span className={wrapperClass}>
@@ -105,12 +135,11 @@ export class TimeTicker extends Component {
         </span>
         {doesHaveDueDate && (
           <div className="sla-details">
-            <div className="sla-part">{`SLA: ${slaPart}`}</div>
+            <div className="sla-part">{slaPart}</div>
             <div className="sla-date">{dueDateStr}</div>
             {elapsed && (
               <div className="elapsed-time">
-                <span>Total Elapsed: </span>
-                <span>{elapsed}</span>
+                {elapsed}
               </div>
             )}
           </div>

--- a/src/components/Cells/TimerCell/TimerCell.js
+++ b/src/components/Cells/TimerCell/TimerCell.js
@@ -10,9 +10,13 @@ class TimerCell extends Component {
     threshold: PropTypes.number
   };
 
+  static isEmpty(extraData) {
+    return !extraData || extraData.runStatus === TIMER_STATUS.idle;
+  }
+
   render() {
     const { extraData } = this.props;
-    if (!extraData || extraData.runStatus === TIMER_STATUS.idle) {
+    if (TimerCell.isEmpty(extraData)) {
       return 'N/A';
     }
 


### PR DESCRIPTION
## Related PRs
- https://github.com/demisto/sane-reports/pull/247

## Description
Displaying the same data for the timer field in the CSV report just as we display in the PDF report

## Flow
- Create an incident with timer fields (Containment SLA, Detection SLA...)
- Go to the incident and update the timer fields using `!startTimer` `!stopTimer` commands
- Create a report with a incidents table widget
- Generate the report using PDF/CSV formats

![Screenshot 2024-05-23 at 14 42 43](https://github.com/demisto/sane-reports/assets/73780437/53c3f9c4-2b18-4943-a432-d960bb404344)

## Debugging
```
it('Generate csv report', () => {
    const testTemplate = loadTemplate('testLayoutCsvWithTimers.json');
```

## JSON
[testLayoutCsvWithTimers.json](https://github.com/demisto/sane-reports/files/15415601/testLayoutCsvWithTimers.json)

```
[
  {
    "type": "table",
    "data": [
      {
        "Containment SLA": "Status: idle",
        "Detection SLA": "Status: running ()",
        "ID": "1",
        "Name": "Test",
        "Remediation SLA": "Status: idle"
      },
      {
        "Containment SLA": "Status: idle",
        "Detection SLA": "Status: running ()",
        "ID": "3",
        "Name": "test 3",
        "Remediation SLA": "Status: running ()"
      },
      {
        "Containment SLA": "Status: ended ()",
        "Detection SLA": "Status: running ()",
        "ID": "2",
        "Name": "test",
        "Remediation SLA": "Status: idle"
      }
    ],
    "layout": {
      "classes": "striped stackable small compact",
      "columnPos": 0,
      "forceRangeMessage": "",
      "h": 3,
      "i": "dd2917b0-fd67-11ed-9bb3-6bd79a4877db",
      "readableHeaders": {
        "Containment SLA": "Containment SLA",
        "Detection SLA": "Detection SLA",
        "Remediation SLA": "Remediation SLA",
        "id": "ID",
        "name": "Name"
      },
      "reflectDimensions": true,
      "rowPos": 0,
      "tableColumns": [
        "id",
        "name",
        "Detection SLA",
        "Containment SLA",
        "Remediation SLA"
      ],
      "tableColumnsMetaData": [
        {
          "displayed": true,
          "isDefault": true,
          "key": "id",
          "width": 110
        },
        {
          "displayed": true,
          "isDefault": true,
          "key": "name",
          "width": 100
        },
        {
          "displayed": true,
          "key": "Detection SLA",
          "width": 200
        },
        {
          "displayed": true,
          "key": "Containment SLA",
          "width": 163
        },
        {
          "displayed": true,
          "key": "Remediation SLA",
          "width": 200
        }
      ],
      "w": 12
    },
    "query": {
      "type": "incident",
      "filter": {
        "query": "",
        "period": {
          "by": "",
          "byTo": "",
          "byFrom": "days",
          "toValue": null,
          "fromValue": 7,
          "field": ""
        },
        "fromDate": "0001-01-01T00:00:00Z",
        "toDate": "0001-01-01T00:00:00Z"
      }
    },
    "extraData": [
      {
        "Detection SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "2023-05-28T18:34:26.447968+03:00",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "running",
          "sla": 20,
          "slaStatus": -1,
          "startDate": "2023-05-28T18:14:26.447968+03:00",
          "totalDuration": 0,
          "threshold": 0
        },
        "Containment SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "0001-01-01T00:00:00Z",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "idle",
          "sla": 30,
          "slaStatus": -1,
          "startDate": "0001-01-01T00:00:00Z",
          "totalDuration": 0,
          "threshold": 3
        },
        "Remediation SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "0001-01-01T00:00:00Z",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "idle",
          "sla": 7200,
          "slaStatus": -1,
          "startDate": "0001-01-01T00:00:00Z",
          "totalDuration": 0,
          "threshold": 0
        }
      },
      {
        "Detection SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "2023-05-28T18:18:40.697968+03:00",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "running",
          "sla": 2,
          "slaStatus": -1,
          "startDate": "2023-05-28T18:16:40.697968+03:00",
          "totalDuration": 0,
          "threshold": 0
        },
        "Containment SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "0001-01-01T00:00:00Z",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "idle",
          "sla": 30,
          "slaStatus": -1,
          "startDate": "0001-01-01T00:00:00Z",
          "totalDuration": 0,
          "threshold": 3
        },
        "Remediation SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "2023-06-03T19:28:32.280921+03:00",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "running",
          "sla": 7200,
          "slaStatus": -1,
          "startDate": "2023-05-29T19:28:32.280921+03:00",
          "totalDuration": 0,
          "threshold": 0
        }
      },
      {
        "Detection SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "2023-05-28T18:15:28.339413+03:00",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "running",
          "sla": 20,
          "slaStatus": -1,
          "startDate": "2023-05-28T17:55:28.339413+03:00",
          "totalDuration": 0,
          "threshold": 0
        },
        "Containment SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "2023-05-29T19:56:29.235357+03:00",
          "endDate": "2023-05-29T19:29:31.44581+03:00",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "ended",
          "sla": 30,
          "slaStatus": 1,
          "startDate": "2023-05-29T19:26:29.235357+03:00",
          "totalDuration": 182,
          "threshold": 3
        },
        "Remediation SLA": {
          "type": "timer",
          "accumulatedPause": 0,
          "breachTriggered": false,
          "dueDate": "0001-01-01T00:00:00Z",
          "endDate": "0001-01-01T00:00:00Z",
          "lastPauseDate": "0001-01-01T00:00:00Z",
          "runStatus": "idle",
          "sla": 7200,
          "slaStatus": -1,
          "startDate": "0001-01-01T00:00:00Z",
          "totalDuration": 0,
          "threshold": 0
        }
      }
    ],
    "automation": {
      "name": "",
      "id": "",
      "args": null,
      "noEvent": false
    },
    "fromDate": "2023-05-22T16:39:57Z",
    "title": "Test",
    "emptyNotification": "No results found",
    "titleStyle": null,
    "autoPageBreak": true
  }
]
```

## Generated CSVs
#### When extraData section doesn't exist
[before_without_extraData.csv](https://github.com/demisto/sane-reports/files/15415608/before_without_extraData.csv)
[after_without_extraData.csv](https://github.com/demisto/sane-reports/files/15415611/after_without_extraData.csv)

![Screenshot 2024-05-23 at 13 38 24](https://github.com/demisto/sane-reports/assets/73780437/66f4e5b8-913a-479b-ba21-e352bf1d7fce)

#### When extraData section exists
[before_with_extraData.csv](https://github.com/demisto/sane-reports/files/15415609/before_with_extraData.csv)
[after_with_extraData.csv](https://github.com/demisto/sane-reports/files/15415610/after_with_extraData.csv)

![Screenshot 2024-05-23 at 13 39 45](https://github.com/demisto/sane-reports/assets/73780437/09965531-7425-4d22-b783-76e37a45ec7d)

## Generated PDFs
[before.pdf](https://github.com/demisto/sane-reports/files/15415872/before.pdf)
[after.pdf](https://github.com/demisto/sane-reports/files/15415878/after.pdf)

![Screenshot 2024-05-23 at 13 57 03](https://github.com/demisto/sane-reports/assets/73780437/02e54b3b-73c1-48c0-bd7a-7efe27a09e77)
